### PR TITLE
[Bounty #77] LinkedIn enrichment endpoints with x402 flow + provider abstraction

### DIFF
--- a/PR-LINKEDIN-ENRICHMENT.md
+++ b/PR-LINKEDIN-ENRICHMENT.md
@@ -1,0 +1,97 @@
+# Bounty Submission: LinkedIn Enrichment API (Bounty #77)
+
+## Scope delivered in this PR
+
+Implemented LinkedIn enrichment API wiring in `src/service.ts` with x402 payment flow and mobile proxy metadata:
+
+- `GET /api/linkedin/person?url=linkedin.com/in/username` — **$0.03**
+- `GET /api/linkedin/company?url=linkedin.com/company/name` — **$0.05**
+- `GET /api/linkedin/search/people?title=CTO&location=San+Francisco&industry=SaaS&limit=10` — **$0.10**
+- `GET /api/linkedin/company/:id/employees?title=engineer&limit=10` — **$0.10**
+
+## Architecture details
+
+Added `src/scrapers/linkedin.ts` with a provider abstraction:
+
+- `LinkedInEnrichmentProvider` interface for mock/live provider swapping
+- `MockLinkedInProvider` (default): deterministic mock data for local/test and CI
+- `LiveLinkedInProvider` (opt-in): session-cookie-based HTML fetch scaffolding over Proxies.sx mobile proxy
+
+Anti-rate-limit/session scaffolding included:
+
+- Per-client LinkedIn route rate limit (`LINKEDIN_MAX_REQ_PER_MIN`, default 12/min)
+- Session pool support via `LINKEDIN_SESSION_COOKIES` (split by `||`)
+- Session backoff on LinkedIn anti-bot responses (HTTP 429 / 999)
+- Mobile proxy metadata in responses (`ip`, `country`, `carrier`, `host`, `type: mobile`)
+
+## x402 flow
+
+All four LinkedIn endpoints:
+
+1. Return standards-based `402` with `build402Response(...)` when no payment signature
+2. Verify on-chain USDC payment via `verifyPayment(...)`
+3. Return paid `200` with `X-Payment-Settled` and `X-Payment-TxHash`
+
+## Config
+
+- `WALLET_ADDRESS` required
+- `LINKEDIN_PROVIDER=mock|live` (default `mock`)
+- `LINKEDIN_SESSION_COOKIES` required when provider is `live`
+- `PROXY_*` required for proxy routing
+- Optional: `PROXY_CARRIER`, `LINKEDIN_MAX_REQ_PER_MIN`
+
+## Validation run in this environment
+
+Because `bun` is not installed in this execution environment, Bun runtime checks and full deployment run were not possible here.
+
+Completed validation:
+
+- `npm install` ✅
+- `npx tsc --noEmit` ✅ (strict TypeScript compile passes)
+
+## Candid status / blockers
+
+- ✅ Endpoint wiring + provider abstraction + x402 payment flow implemented.
+- ✅ Anti-rate-limit and session handling scaffolding implemented.
+- ⚠️ Live production LinkedIn extraction quality depends on valid rotating LinkedIn sessions and environment-specific anti-bot behavior.
+- ⚠️ Full bounty acceptance items (10+ real profile extractions, 3+ real company records, live deployed URL proof) are **not produced in this local environment** due missing Bun runtime + no production credentials/deployment target in-session.
+
+## Deploy/test instructions for reviewer
+
+1. Install Bun (required by repo runtime):
+   ```bash
+   curl -fsSL https://bun.sh/install | bash
+   ```
+2. Configure `.env` with:
+   - `WALLET_ADDRESS`
+   - `PROXY_HOST`, `PROXY_HTTP_PORT`, `PROXY_USER`, `PROXY_PASS`
+   - `LINKEDIN_PROVIDER=live`
+   - `LINKEDIN_SESSION_COOKIES="li_at=...; JSESSIONID=...||li_at=...; JSESSIONID=..."`
+3. Start service:
+   ```bash
+   bun install
+   bun run dev
+   ```
+4. Verify x402 preflight:
+   ```bash
+   curl -i "http://localhost:3000/api/linkedin/person?url=linkedin.com/in/janesmith"
+   ```
+5. Verify paid request:
+   ```bash
+   curl -sS \
+     -H "Payment-Signature: <tx_hash>" \
+     -H "X-Payment-Network: solana" \
+     "http://localhost:3000/api/linkedin/person?url=linkedin.com/in/janesmith" | jq
+   ```
+
+## Evidence path
+
+- Compile evidence: local command output from `npx tsc --noEmit`
+- API evidence path after deployment:
+  - save 10 person JSON responses under `listings/linkedin-proof-person-*.json`
+  - save 3 company JSON responses under `listings/linkedin-proof-company-*.json`
+  - save search response under `listings/linkedin-proof-search-*.json`
+
+## Solana USDC wallet
+
+Uses service `WALLET_ADDRESS` env var (same x402 flow as template).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "marketplace-service-template",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "marketplace-service-template",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "hono": "^4.6.0"
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.9.tgz",
+      "integrity": "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.9"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.9.tgz",
+      "integrity": "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ app.get('/health', (c) => c.json({
   service: process.env.SERVICE_NAME || 'marketplace-service',
   version: '1.0.0',
   timestamp: new Date().toISOString(),
-  endpoints: ['/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/reviews/summary/:place_id', '/api/business/:place_id'],
+  endpoints: ['/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/reviews/summary/:place_id', '/api/business/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/linkedin/company/:id/employees'],
 }));
 
 app.get('/', (c) => c.json({
@@ -79,6 +79,10 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/reviews/:place_id', description: 'Fetch Google reviews by Place ID', price: '0.02 USDC' },
     { method: 'GET', path: '/api/business/:place_id', description: 'Get business details + review summary', price: '0.01 USDC' },
     { method: 'GET', path: '/api/reviews/summary/:place_id', description: 'Get review summary stats', price: '0.005 USDC' },
+    { method: 'GET', path: '/api/linkedin/person', description: 'LinkedIn person enrichment by profile URL', price: '0.03 USDC' },
+    { method: 'GET', path: '/api/linkedin/company', description: 'LinkedIn company enrichment by company URL', price: '0.05 USDC' },
+    { method: 'GET', path: '/api/linkedin/search/people', description: 'LinkedIn people search by title/location/industry', price: '0.10 USDC' },
+    { method: 'GET', path: '/api/linkedin/company/:id/employees', description: 'LinkedIn employee lookup by company + title', price: '0.10 USDC' },
   ],
   pricing: {
     amount: process.env.PRICE_USDC || '0.005',
@@ -112,7 +116,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/linkedin/company/:id/employees'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/scrapers/linkedin.ts
+++ b/src/scrapers/linkedin.ts
@@ -1,0 +1,477 @@
+import { getProxy, proxyFetch } from '../proxy';
+
+export interface LinkedInProxyMeta {
+  ip: string | null;
+  country: string;
+  carrier: string;
+  host: string;
+  type: 'mobile';
+}
+
+export interface LinkedInPersonProfile {
+  name: string;
+  headline: string;
+  location: string;
+  current_company: {
+    name: string;
+    title: string;
+    started: string;
+  };
+  previous_companies: Array<{ name: string; title: string; period: string }>;
+  education: Array<{ school: string; degree: string }>;
+  skills: string[];
+  connections: string;
+  profile_url: string;
+}
+
+export interface LinkedInCompanyProfile {
+  id: string;
+  name: string;
+  description: string;
+  industry: string;
+  headquarters: string;
+  employee_count: string;
+  employee_growth_rate: string;
+  job_openings: number;
+  tech_stack_signals: string[];
+  company_url: string;
+}
+
+export interface LinkedInPeopleSearchResult {
+  query: {
+    title: string;
+    location: string;
+    industry: string;
+    limit: number;
+  };
+  results: LinkedInPersonProfile[];
+}
+
+export interface LinkedInEmployeeSearchResult {
+  company_id: string;
+  title: string;
+  total: number;
+  employees: LinkedInPersonProfile[];
+}
+
+export interface LinkedInEnrichmentProvider {
+  providerName: string;
+  isMock: boolean;
+  getPersonByUrl(url: string): Promise<LinkedInPersonProfile>;
+  getCompanyByUrl(url: string): Promise<LinkedInCompanyProfile>;
+  searchPeople(params: { title: string; location: string; industry: string; limit: number }): Promise<LinkedInPeopleSearchResult>;
+  getCompanyEmployees(companyId: string, title: string, limit: number): Promise<LinkedInEmployeeSearchResult>;
+}
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_PER_CLIENT = parseInt(process.env.LINKEDIN_MAX_REQ_PER_MIN || '12');
+const clientRateLimit = new Map<string, { count: number; resetAt: number }>();
+
+const accountStates = new Map<string, { nextAllowedAt: number; failures: number }>();
+
+function clampLimit(v: number, max = 10): number {
+  if (!Number.isFinite(v)) return max;
+  return Math.min(Math.max(Math.floor(v), 1), max);
+}
+
+function seededPick<T>(seed: number, values: T[]): T {
+  return values[Math.abs(seed) % values.length]!;
+}
+
+function strHash(input: string): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) {
+    h = (h << 5) - h + input.charCodeAt(i);
+    h |= 0;
+  }
+  return Math.abs(h);
+}
+
+function normalizeLinkedInUrl(input: string): string {
+  const withProtocol = /^https?:\/\//i.test(input) ? input : `https://${input}`;
+  const parsed = new URL(withProtocol);
+  parsed.hash = '';
+  parsed.search = '';
+  return parsed.toString().replace(/\/$/, '');
+}
+
+export function checkLinkedInRateLimit(clientIp: string): { allowed: boolean; retryAfter?: number } {
+  const now = Date.now();
+  const key = clientIp || 'unknown';
+  const current = clientRateLimit.get(key);
+  if (!current || now > current.resetAt) {
+    clientRateLimit.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { allowed: true };
+  }
+
+  current.count += 1;
+  if (current.count > RATE_LIMIT_MAX_PER_CLIENT) {
+    return { allowed: false, retryAfter: Math.ceil((current.resetAt - now) / 1000) };
+  }
+
+  return { allowed: true };
+}
+
+export async function getProxyExitIp(): Promise<string | null> {
+  try {
+    const r = await proxyFetch('https://api.ipify.org?format=json', {
+      headers: { Accept: 'application/json' },
+      maxRetries: 1,
+      timeoutMs: 15_000,
+    });
+    if (!r.ok) return null;
+    const data = await r.json() as any;
+    return typeof data?.ip === 'string' ? data.ip : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function buildLinkedInMeta(): Promise<LinkedInProxyMeta> {
+  const proxy = getProxy();
+  return {
+    ip: await getProxyExitIp(),
+    country: proxy.country,
+    carrier: process.env.PROXY_CARRIER || 'unknown-mobile-carrier',
+    host: proxy.host,
+    type: 'mobile',
+  };
+}
+
+class MockLinkedInProvider implements LinkedInEnrichmentProvider {
+  providerName = 'mock-linkedin-provider';
+  isMock = true;
+
+  async getPersonByUrl(url: string): Promise<LinkedInPersonProfile> {
+    const profileUrl = normalizeLinkedInUrl(url);
+    const seed = strHash(profileUrl);
+    return mockPersonFromSeed(seed, profileUrl);
+  }
+
+  async getCompanyByUrl(url: string): Promise<LinkedInCompanyProfile> {
+    const companyUrl = normalizeLinkedInUrl(url);
+    const seed = strHash(companyUrl);
+    return mockCompanyFromSeed(seed, companyUrl);
+  }
+
+  async searchPeople(params: { title: string; location: string; industry: string; limit: number }): Promise<LinkedInPeopleSearchResult> {
+    const limit = clampLimit(params.limit, 10);
+    const results: LinkedInPersonProfile[] = [];
+
+    for (let i = 0; i < limit; i++) {
+      const url = `https://linkedin.com/in/${slugify(`${params.title}-${params.location}-${params.industry}-${i}`)}`;
+      results.push(mockPersonFromSeed(strHash(url), url, {
+        headline: `${params.title} in ${params.industry}`,
+        location: params.location,
+      }));
+    }
+
+    return { query: { ...params, limit }, results };
+  }
+
+  async getCompanyEmployees(companyId: string, title: string, limit: number): Promise<LinkedInEmployeeSearchResult> {
+    const safeLimit = clampLimit(limit, 25);
+    const employees: LinkedInPersonProfile[] = [];
+
+    for (let i = 0; i < safeLimit; i++) {
+      const url = `https://linkedin.com/in/${slugify(`${companyId}-${title}-${i}`)}`;
+      employees.push(mockPersonFromSeed(strHash(url), url, {
+        headline: `${title} at ${companyId}`,
+      }));
+    }
+
+    return {
+      company_id: companyId,
+      title,
+      total: employees.length,
+      employees,
+    };
+  }
+}
+
+class LiveLinkedInProvider implements LinkedInEnrichmentProvider {
+  providerName = 'live-linkedin-html-provider';
+  isMock = false;
+  private sessionPool: string[];
+
+  constructor() {
+    this.sessionPool = (process.env.LINKEDIN_SESSION_COOKIES || '')
+      .split('||')
+      .map(v => v.trim())
+      .filter(Boolean);
+
+    if (this.sessionPool.length === 0) {
+      throw new Error('LINKEDIN_SESSION_COOKIES not configured for live provider');
+    }
+  }
+
+  private pickSession() {
+    const now = Date.now();
+    let best = this.sessionPool[0]!;
+    let bestAllowed = Number.MAX_SAFE_INTEGER;
+
+    for (const s of this.sessionPool) {
+      const state = accountStates.get(s) || { nextAllowedAt: 0, failures: 0 };
+      if (state.nextAllowedAt <= now) return s;
+      if (state.nextAllowedAt < bestAllowed) {
+        best = s;
+        bestAllowed = state.nextAllowedAt;
+      }
+    }
+
+    return best;
+  }
+
+  private markSessionResult(session: string, status: number) {
+    const current = accountStates.get(session) || { nextAllowedAt: 0, failures: 0 };
+
+    if (status === 429 || status === 999) {
+      const failures = current.failures + 1;
+      const backoffMs = Math.min(120_000, 2 ** failures * 1_000);
+      accountStates.set(session, { failures, nextAllowedAt: Date.now() + backoffMs });
+      return;
+    }
+
+    if (status >= 200 && status < 400) {
+      accountStates.set(session, { failures: 0, nextAllowedAt: 0 });
+    }
+  }
+
+  private async fetchHtml(url: string): Promise<string> {
+    const target = normalizeLinkedInUrl(url);
+    const session = this.pickSession();
+
+    const response = await proxyFetch(target, {
+      headers: {
+        Cookie: session,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+      timeoutMs: 25_000,
+      maxRetries: 1,
+    });
+
+    this.markSessionResult(session, response.status);
+
+    if (!response.ok) {
+      throw new Error(`LinkedIn request failed (${response.status})`);
+    }
+
+    return response.text();
+  }
+
+  async getPersonByUrl(url: string): Promise<LinkedInPersonProfile> {
+    const profileUrl = normalizeLinkedInUrl(url);
+    const html = await this.fetchHtml(profileUrl);
+    return parsePersonFromHtml(profileUrl, html);
+  }
+
+  async getCompanyByUrl(url: string): Promise<LinkedInCompanyProfile> {
+    const companyUrl = normalizeLinkedInUrl(url);
+    const html = await this.fetchHtml(companyUrl);
+    return parseCompanyFromHtml(companyUrl, html);
+  }
+
+  async searchPeople(params: { title: string; location: string; industry: string; limit: number }): Promise<LinkedInPeopleSearchResult> {
+    const limit = clampLimit(params.limit, 10);
+    const searchUrl = new URL('https://www.linkedin.com/search/results/people/');
+    searchUrl.searchParams.set('keywords', params.title);
+    if (params.location) searchUrl.searchParams.set('geoUrn', params.location);
+
+    const html = await this.fetchHtml(searchUrl.toString());
+    const profiles = extractProfileUrlsFromSearchHtml(html).slice(0, limit);
+
+    const results = await Promise.all(profiles.map((profileUrl) => this.getPersonByUrl(profileUrl)));
+    return {
+      query: { ...params, limit },
+      results,
+    };
+  }
+
+  async getCompanyEmployees(companyId: string, title: string, limit: number): Promise<LinkedInEmployeeSearchResult> {
+    const safeLimit = clampLimit(limit, 25);
+    const target = `https://www.linkedin.com/company/${encodeURIComponent(companyId)}/people/`;
+    const html = await this.fetchHtml(target);
+    const profileUrls = extractProfileUrlsFromSearchHtml(html).slice(0, safeLimit);
+    const employees = await Promise.all(profileUrls.map((u) => this.getPersonByUrl(u)));
+
+    return { company_id: companyId, title, total: employees.length, employees };
+  }
+}
+
+function parsePersonFromHtml(url: string, html: string): LinkedInPersonProfile {
+  const jsonLd = extractJsonLd(html);
+  const name = pickFirstString(jsonLd, ['name']) || inferNameFromUrl(url);
+  const headline = pickFirstString(jsonLd, ['description']) || extractOgTitle(html) || 'LinkedIn member';
+  const location = pickFromRegex(html, /"locationName":"([^"]+)"/i) || 'Unknown';
+
+  return {
+    name,
+    headline,
+    location,
+    current_company: {
+      name: pickFromRegex(html, /"companyName":"([^"]+)"/i) || 'Unknown Company',
+      title: pickFromRegex(html, /"title":"([^"]+)"/i) || headline,
+      started: pickFromRegex(html, /"startedOn":"([^"]+)"/i) || 'unknown',
+    },
+    previous_companies: [],
+    education: [],
+    skills: extractSkills(html),
+    connections: pickFromRegex(html, /"numConnections":(\d+)/i)?.concat('+') || 'N/A',
+    profile_url: normalizeLinkedInUrl(url),
+  };
+}
+
+function parseCompanyFromHtml(url: string, html: string): LinkedInCompanyProfile {
+  const jsonLd = extractJsonLd(html);
+  const name = pickFirstString(jsonLd, ['name']) || inferCompanyFromUrl(url);
+  return {
+    id: normalizeLinkedInUrl(url).split('/').pop() || name,
+    name,
+    description: pickFirstString(jsonLd, ['description']) || extractMetaDescription(html) || 'No description available',
+    industry: pickFromRegex(html, /"industry":\{"name":"([^"]+)"/i) || 'Unknown',
+    headquarters: pickFromRegex(html, /"headquarter":\{"country":"([^"]+)"/i) || 'Unknown',
+    employee_count: pickFromRegex(html, /"staffCount":(\d+)/i) || 'Unknown',
+    employee_growth_rate: 'unknown',
+    job_openings: Number(pickFromRegex(html, /"jobPostingsCount":(\d+)/i) || 0),
+    tech_stack_signals: extractTechStackSignals(html),
+    company_url: normalizeLinkedInUrl(url),
+  };
+}
+
+function extractJsonLd(html: string): any {
+  const match = html.match(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/i);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1] || 'null');
+  } catch {
+    return null;
+  }
+}
+
+function pickFirstString(obj: any, keys: string[]): string | null {
+  if (!obj || typeof obj !== 'object') return null;
+  for (const k of keys) {
+    const val = obj[k];
+    if (typeof val === 'string' && val.trim()) return val.trim();
+  }
+  return null;
+}
+
+function pickFromRegex(input: string, regex: RegExp): string | null {
+  const m = input.match(regex);
+  return m?.[1] ? decodeHtml(m[1]) : null;
+}
+
+function decodeHtml(s: string): string {
+  return s
+    .replace(/\\u0026/g, '&')
+    .replace(/\\\"/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .trim();
+}
+
+function extractMetaDescription(html: string): string | null {
+  const m = html.match(/<meta\s+name="description"\s+content="([^"]+)"/i);
+  return m?.[1] ? decodeHtml(m[1]) : null;
+}
+
+function extractOgTitle(html: string): string | null {
+  const m = html.match(/<meta\s+property="og:title"\s+content="([^"]+)"/i);
+  return m?.[1] ? decodeHtml(m[1]) : null;
+}
+
+function extractSkills(html: string): string[] {
+  const candidates = ['Python', 'TypeScript', 'Machine Learning', 'Sales', 'Product Management', 'System Design'];
+  return candidates.filter((c) => html.toLowerCase().includes(c.toLowerCase())).slice(0, 8);
+}
+
+function extractTechStackSignals(html: string): string[] {
+  const candidates = ['AWS', 'GCP', 'Azure', 'Kubernetes', 'React', 'Salesforce', 'Snowflake'];
+  const found = candidates.filter((c) => html.toLowerCase().includes(c.toLowerCase()));
+  return found.length > 0 ? found : ['not-detected'];
+}
+
+function inferNameFromUrl(url: string): string {
+  const slug = normalizeLinkedInUrl(url).split('/').pop() || 'member';
+  return slug
+    .split('-')
+    .map((v) => v.charAt(0).toUpperCase() + v.slice(1))
+    .join(' ');
+}
+
+function inferCompanyFromUrl(url: string): string {
+  return inferNameFromUrl(url);
+}
+
+function slugify(v: string): string {
+  return v.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+function mockPersonFromSeed(seed: number, profileUrl: string, override?: Partial<Pick<LinkedInPersonProfile, 'headline' | 'location'>>): LinkedInPersonProfile {
+  const firstNames = ['Jane', 'Alex', 'Taylor', 'Jordan', 'Riley', 'Casey', 'Morgan'];
+  const lastNames = ['Smith', 'Lee', 'Patel', 'Garcia', 'Khan', 'Nguyen', 'Brown'];
+  const companies = ['TechCorp', 'DataScale', 'Orbit Systems', 'Nimbus Labs', 'Acme AI'];
+  const titles = ['Chief Technology Officer', 'VP Engineering', 'Head of Data', 'Staff Engineer', 'Product Lead'];
+  const locations = ['San Francisco, CA', 'New York, NY', 'Austin, TX', 'Singapore', 'Sydney, AU'];
+
+  const fullName = `${seededPick(seed, firstNames)} ${seededPick(seed + 7, lastNames)}`;
+  const company = seededPick(seed + 13, companies);
+  const title = seededPick(seed + 23, titles);
+  const location = override?.location || seededPick(seed + 31, locations);
+
+  return {
+    name: fullName,
+    headline: override?.headline || `${title} at ${company}`,
+    location,
+    current_company: {
+      name: company,
+      title,
+      started: `${2020 + (seed % 5)}-0${(seed % 9) + 1}`,
+    },
+    previous_companies: [
+      { name: seededPick(seed + 3, companies), title: seededPick(seed + 5, titles), period: '2019-2022' },
+      { name: seededPick(seed + 11, companies), title: seededPick(seed + 19, titles), period: '2016-2019' },
+    ],
+    education: [{ school: 'Stanford University', degree: 'MS Computer Science' }],
+    skills: ['Python', 'Machine Learning', 'System Design', 'Leadership'].slice(0, 3 + (seed % 2)),
+    connections: seed % 2 === 0 ? '500+' : '200+',
+    profile_url: profileUrl,
+  };
+}
+
+function mockCompanyFromSeed(seed: number, companyUrl: string): LinkedInCompanyProfile {
+  const industries = ['SaaS', 'FinTech', 'HealthTech', 'AI Infrastructure', 'Cybersecurity'];
+  const hq = ['San Francisco, US', 'London, UK', 'Singapore', 'Berlin, DE', 'Sydney, AU'];
+
+  const name = inferCompanyFromUrl(companyUrl);
+
+  return {
+    id: name.toLowerCase().replace(/\s+/g, '-'),
+    name,
+    description: `${name} builds B2B software products for enterprise customers.`,
+    industry: seededPick(seed + 5, industries),
+    headquarters: seededPick(seed + 17, hq),
+    employee_count: String(50 + (seed % 3000)),
+    employee_growth_rate: `${(seed % 40) + 5}% YoY`,
+    job_openings: seed % 50,
+    tech_stack_signals: ['AWS', 'Kubernetes', 'TypeScript'],
+    company_url: companyUrl,
+  };
+}
+
+function extractProfileUrlsFromSearchHtml(html: string): string[] {
+  const urls = new Set<string>();
+  const regex = /https:\/\/www\.linkedin\.com\/in\/[a-zA-Z0-9\-_%]+/g;
+  const matches = html.match(regex) || [];
+  for (const m of matches) {
+    urls.add(m.replace(/%2F/g, '/').replace(/\/$/, ''));
+  }
+  return [...urls];
+}
+
+export function getLinkedInProvider(): LinkedInEnrichmentProvider {
+  const mode = (process.env.LINKEDIN_PROVIDER || 'mock').toLowerCase();
+  if (mode === 'live') return new LiveLinkedInProvider();
+  return new MockLinkedInProvider();
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,12 +10,17 @@ import { proxyFetch, getProxy } from './proxy';
 import { extractPayment, verifyPayment, build402Response } from './payment';
 import { scrapeIndeed, scrapeLinkedIn, type JobListing } from './scrapers/job-scraper';
 import { fetchReviews, fetchBusinessDetails, fetchReviewSummary, searchBusinesses } from './scrapers/reviews';
+import { getLinkedInProvider, checkLinkedInRateLimit, buildLinkedInMeta } from './scrapers/linkedin';
 
 export const serviceRouter = new Hono();
 
 const SERVICE_NAME = 'job-market-intelligence';
 const PRICE_USDC = 0.005;
 const DESCRIPTION = 'Job Market Intelligence API (Indeed/LinkedIn): title, company, location, salary, date, link, remote + proxy exit metadata.';
+
+const LINKEDIN_PERSON_PRICE_USDC = 0.03;
+const LINKEDIN_COMPANY_PRICE_USDC = 0.05;
+const LINKEDIN_SEARCH_PRICE_USDC = 0.10;
 
 async function getProxyExitIp(): Promise<string | null> {
   try {
@@ -333,5 +338,221 @@ serviceRouter.get('/business/:place_id', async (c) => {
     });
   } catch (err: any) {
     return c.json({ error: 'Business details fetch failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ═══════════════════════════════════════════════════════
+// ─── LINKEDIN ENRICHMENT API (Bounty #77) ───────────
+// ═══════════════════════════════════════════════════════
+
+serviceRouter.get('/linkedin/person', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/linkedin/person', 'LinkedIn person enrichment by profile URL', LINKEDIN_PERSON_PRICE_USDC, walletAddress, {
+      input: { url: 'string (required) — linkedin.com/in/username' },
+      output: { name: 'string', headline: 'string', location: 'string', current_company: 'object', skills: 'string[]', meta: '{ proxy, provider, mock }' },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, LINKEDIN_PERSON_PRICE_USDC);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const clientIp = c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const allowed = checkLinkedInRateLimit(clientIp);
+  if (!allowed.allowed) {
+    c.header('Retry-After', String(allowed.retryAfter || 60));
+    return c.json({ error: 'LinkedIn rate limit exceeded for this client', retryAfter: allowed.retryAfter || 60 }, 429);
+  }
+
+  const url = c.req.query('url');
+  if (!url) return c.json({ error: 'Missing required parameter: url', example: '/api/linkedin/person?url=linkedin.com/in/janesmith' }, 400);
+
+  try {
+    const provider = getLinkedInProvider();
+    const [profile, proxyMeta] = await Promise.all([
+      provider.getPersonByUrl(url),
+      buildLinkedInMeta(),
+    ]);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      ...profile,
+      meta: {
+        proxy: proxyMeta,
+        provider: provider.providerName,
+        mock: provider.isMock,
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'LinkedIn person enrichment failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+serviceRouter.get('/linkedin/company', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/linkedin/company', 'LinkedIn company enrichment by company URL', LINKEDIN_COMPANY_PRICE_USDC, walletAddress, {
+      input: { url: 'string (required) — linkedin.com/company/name' },
+      output: { id: 'string', name: 'string', industry: 'string', employee_count: 'string', job_openings: 'number', meta: '{ proxy, provider, mock }' },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, LINKEDIN_COMPANY_PRICE_USDC);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const clientIp = c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const allowed = checkLinkedInRateLimit(clientIp);
+  if (!allowed.allowed) {
+    c.header('Retry-After', String(allowed.retryAfter || 60));
+    return c.json({ error: 'LinkedIn rate limit exceeded for this client', retryAfter: allowed.retryAfter || 60 }, 429);
+  }
+
+  const url = c.req.query('url');
+  if (!url) return c.json({ error: 'Missing required parameter: url', example: '/api/linkedin/company?url=linkedin.com/company/openai' }, 400);
+
+  try {
+    const provider = getLinkedInProvider();
+    const [company, proxyMeta] = await Promise.all([
+      provider.getCompanyByUrl(url),
+      buildLinkedInMeta(),
+    ]);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      ...company,
+      meta: {
+        proxy: proxyMeta,
+        provider: provider.providerName,
+        mock: provider.isMock,
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'LinkedIn company enrichment failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+serviceRouter.get('/linkedin/search/people', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/linkedin/search/people', 'LinkedIn people search by title + location + industry', LINKEDIN_SEARCH_PRICE_USDC, walletAddress, {
+      input: {
+        title: 'string (required) — e.g. CTO',
+        location: 'string (optional, default: United States)',
+        industry: 'string (optional, default: SaaS)',
+        limit: 'number (optional, default: 10, max: 10)',
+      },
+      output: { query: 'object', results: 'LinkedInPersonProfile[]', meta: '{ proxy, provider, mock }' },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, LINKEDIN_SEARCH_PRICE_USDC);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const clientIp = c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const allowed = checkLinkedInRateLimit(clientIp);
+  if (!allowed.allowed) {
+    c.header('Retry-After', String(allowed.retryAfter || 60));
+    return c.json({ error: 'LinkedIn rate limit exceeded for this client', retryAfter: allowed.retryAfter || 60 }, 429);
+  }
+
+  const title = c.req.query('title');
+  const location = c.req.query('location') || 'United States';
+  const industry = c.req.query('industry') || 'SaaS';
+  const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '10') || 10, 1), 10);
+
+  if (!title) return c.json({ error: 'Missing required parameter: title', example: '/api/linkedin/search/people?title=CTO&location=San+Francisco&industry=SaaS' }, 400);
+
+  try {
+    const provider = getLinkedInProvider();
+    const [searchResult, proxyMeta] = await Promise.all([
+      provider.searchPeople({ title, location, industry, limit }),
+      buildLinkedInMeta(),
+    ]);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      ...searchResult,
+      meta: {
+        proxy: proxyMeta,
+        provider: provider.providerName,
+        mock: provider.isMock,
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'LinkedIn people search failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+serviceRouter.get('/linkedin/company/:id/employees', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/linkedin/company/:id/employees', 'LinkedIn employee lookup by company and title', LINKEDIN_SEARCH_PRICE_USDC, walletAddress, {
+      input: {
+        id: 'string (required) — LinkedIn company slug in URL path',
+        title: 'string (optional, default: engineer)',
+        limit: 'number (optional, default: 10, max: 25)',
+      },
+      output: { company_id: 'string', title: 'string', total: 'number', employees: 'LinkedInPersonProfile[]', meta: '{ proxy, provider, mock }' },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, LINKEDIN_SEARCH_PRICE_USDC);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const clientIp = c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const allowed = checkLinkedInRateLimit(clientIp);
+  if (!allowed.allowed) {
+    c.header('Retry-After', String(allowed.retryAfter || 60));
+    return c.json({ error: 'LinkedIn rate limit exceeded for this client', retryAfter: allowed.retryAfter || 60 }, 429);
+  }
+
+  const companyId = c.req.param('id');
+  const title = c.req.query('title') || 'engineer';
+  const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '10') || 10, 1), 25);
+
+  if (!companyId) return c.json({ error: 'Missing company id in path', example: '/api/linkedin/company/openai/employees?title=engineer' }, 400);
+
+  try {
+    const provider = getLinkedInProvider();
+    const [employeesResult, proxyMeta] = await Promise.all([
+      provider.getCompanyEmployees(companyId, title, limit),
+      buildLinkedInMeta(),
+    ]);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      ...employeesResult,
+      meta: {
+        proxy: proxyMeta,
+        provider: provider.providerName,
+        mock: provider.isMock,
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'LinkedIn employee lookup failed', message: err?.message || String(err) }, 502);
   }
 });


### PR DESCRIPTION
# Bounty Submission: LinkedIn Enrichment API (Bounty #77)

## Scope delivered in this PR

Implemented LinkedIn enrichment API wiring in `src/service.ts` with x402 payment flow and mobile proxy metadata:

- `GET /api/linkedin/person?url=linkedin.com/in/username` — **$0.03**
- `GET /api/linkedin/company?url=linkedin.com/company/name` — **$0.05**
- `GET /api/linkedin/search/people?title=CTO&location=San+Francisco&industry=SaaS&limit=10` — **$0.10**
- `GET /api/linkedin/company/:id/employees?title=engineer&limit=10` — **$0.10**

## Architecture details

Added `src/scrapers/linkedin.ts` with a provider abstraction:

- `LinkedInEnrichmentProvider` interface for mock/live provider swapping
- `MockLinkedInProvider` (default): deterministic mock data for local/test and CI
- `LiveLinkedInProvider` (opt-in): session-cookie-based HTML fetch scaffolding over Proxies.sx mobile proxy

Anti-rate-limit/session scaffolding included:

- Per-client LinkedIn route rate limit (`LINKEDIN_MAX_REQ_PER_MIN`, default 12/min)
- Session pool support via `LINKEDIN_SESSION_COOKIES` (split by `||`)
- Session backoff on LinkedIn anti-bot responses (HTTP 429 / 999)
- Mobile proxy metadata in responses (`ip`, `country`, `carrier`, `host`, `type: mobile`)

## x402 flow

All four LinkedIn endpoints:

1. Return standards-based `402` with `build402Response(...)` when no payment signature
2. Verify on-chain USDC payment via `verifyPayment(...)`
3. Return paid `200` with `X-Payment-Settled` and `X-Payment-TxHash`

## Config

- `WALLET_ADDRESS` required
- `LINKEDIN_PROVIDER=mock|live` (default `mock`)
- `LINKEDIN_SESSION_COOKIES` required when provider is `live`
- `PROXY_*` required for proxy routing
- Optional: `PROXY_CARRIER`, `LINKEDIN_MAX_REQ_PER_MIN`

## Validation run in this environment

Because `bun` is not installed in this execution environment, Bun runtime checks and full deployment run were not possible here.

Completed validation:

- `npm install` ✅
- `npx tsc --noEmit` ✅ (strict TypeScript compile passes)

## Candid status / blockers

- ✅ Endpoint wiring + provider abstraction + x402 payment flow implemented.
- ✅ Anti-rate-limit and session handling scaffolding implemented.
- ⚠️ Live production LinkedIn extraction quality depends on valid rotating LinkedIn sessions and environment-specific anti-bot behavior.
- ⚠️ Full bounty acceptance items (10+ real profile extractions, 3+ real company records, live deployed URL proof) are **not produced in this local environment** due missing Bun runtime + no production credentials/deployment target in-session.

## Deploy/test instructions for reviewer

1. Install Bun (required by repo runtime):
   ```bash
   curl -fsSL https://bun.sh/install | bash
   ```
2. Configure `.env` with:
   - `WALLET_ADDRESS`
   - `PROXY_HOST`, `PROXY_HTTP_PORT`, `PROXY_USER`, `PROXY_PASS`
   - `LINKEDIN_PROVIDER=live`
   - `LINKEDIN_SESSION_COOKIES="li_at=...; JSESSIONID=...||li_at=...; JSESSIONID=..."`
3. Start service:
   ```bash
   bun install
   bun run dev
   ```
4. Verify x402 preflight:
   ```bash
   curl -i "http://localhost:3000/api/linkedin/person?url=linkedin.com/in/janesmith"
   ```
5. Verify paid request:
   ```bash
   curl -sS \
     -H "Payment-Signature: <tx_hash>" \
     -H "X-Payment-Network: solana" \
     "http://localhost:3000/api/linkedin/person?url=linkedin.com/in/janesmith" | jq
   ```

## Evidence path

- Compile evidence: local command output from `npx tsc --noEmit`
- API evidence path after deployment:
  - save 10 person JSON responses under `listings/linkedin-proof-person-*.json`
  - save 3 company JSON responses under `listings/linkedin-proof-company-*.json`
  - save search response under `listings/linkedin-proof-search-*.json`

## Solana USDC wallet

Uses service `WALLET_ADDRESS` env var (same x402 flow as template).
