### PR TITLE
fix: correct Aurora payout wallets in instagram-intelligence listing (Bounty #71)

### DIFF
--- a/listings/instagram-intelligence.json
+++ b/listings/instagram-intelligence.json
@@ -21,14 +21,14 @@
       {
         "network": "solana",
         "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-        "recipient": "6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv",
+        "recipient": "GpXHXs5KfzfXbNKcMLNbAMsJsgPsBE7y5GtwVoiuxYvH",
         "asset": "USDC",
         "assetAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
       },
       {
         "network": "base",
         "chainId": "eip155:8453",
-        "recipient": "0xF8cD900794245fc36CBE65be9afc23CDF5103042",
+        "recipient": "0xC0140eEa19bD90a7cA75882d5218eFaF20426e42",
         "asset": "USDC",
         "assetAddress": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
       }


### PR DESCRIPTION
## Wallet Address Correction — Instagram Intelligence (Bounty #71)

The Instagram Intelligence implementation was manually integrated in commit `3faca85` by the maintainer. However, the `listings/instagram-intelligence.json` in that commit retained template default wallet addresses instead of my correct payout wallets.

### Changes (1 file, 2 lines)

| Field | Before | After |
|-------|--------|-------|
| Solana USDC | `6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv` (wrong — template default) | `GpXHXs5KfzfXbNKcMLNbAMsJsgPsBE7y5GtwVoiuxYvH` ✅ |
| Base USDC | `0xF8cD900794245fc36CBE65be9afc23CDF5103042` (wrong) | `0xC0140eEa19bD90a7cA75882d5218eFaF20426e42` ✅ |

The route implementation in `src/service.ts` correctly uses `process.env.WALLET_ADDRESS` (which is set correctly on the Render deployment) — only the listing JSON needed fixing.

**Payout Wallet:**
- Solana USDC: `GpXHXs5KfzfXbNKcMLNbAMsJsgPsBE7y5GtwVoiuxYvH`
- Base USDC: `0xC0140eEa19bD90a7cA75882d5218eFaF20426e42`