### PR TITLE
feat: add paid /api/instagram/discover endpoint with validated AI filters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,16 @@ PROXY_USER=
 PROXY_PASS=
 PROXY_COUNTRY=US
 
+# ─── INSTAGRAM AI VISION / DISCOVERY (optional) ───
+# Vision provider: openai-compatible | openai | anthropic
+# VISION_PROVIDER=openai-compatible
+# VISION_API_KEY=
+# VISION_BASE_URL=https://api.openai.com/v1
+# VISION_MODEL=gpt-4o
+# ANTHROPIC_API_KEY=
+# Discovery seed usernames (comma-separated public accounts)
+# IG_DISCOVER_SEED_USERNAMES=natgeo,nasa,nike,cristiano,therock
+
 # ─── OPTIONAL: Custom RPC endpoints ───
 # SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
 # BASE_RPC_URL=https://mainnet.base.org

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,12 @@ app.get('/health', (c) => c.json({
     '/api/reviews/:place_id',
     '/api/reviews/summary/:place_id',
     '/api/business/:place_id',
+    '/api/instagram/profile/:username',
+    '/api/instagram/posts/:username',
+    '/api/instagram/analyze/:username',
+    '/api/instagram/analyze/:username/images',
+    '/api/instagram/audit/:username',
+    '/api/instagram/discover',
     '/api/airbnb/search',
     '/api/airbnb/listing/:id',
     '/api/airbnb/reviews/:listing_id',
@@ -95,6 +101,12 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/reviews/:place_id', description: 'Fetch Google reviews by Place ID', price: '0.02 USDC' },
     { method: 'GET', path: '/api/business/:place_id', description: 'Get business details + review summary', price: '0.01 USDC' },
     { method: 'GET', path: '/api/reviews/summary/:place_id', description: 'Get review summary stats', price: '0.005 USDC' },
+    { method: 'GET', path: '/api/instagram/profile/:username', description: 'Instagram profile intelligence', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/instagram/posts/:username', description: 'Instagram post feed intelligence', price: '0.02 USDC' },
+    { method: 'GET', path: '/api/instagram/analyze/:username', description: 'Full Instagram AI vision analysis', price: '0.15 USDC' },
+    { method: 'GET', path: '/api/instagram/analyze/:username/images', description: 'Instagram image-only AI vision analysis', price: '0.08 USDC' },
+    { method: 'GET', path: '/api/instagram/audit/:username', description: 'Instagram authenticity audit', price: '0.05 USDC' },
+    { method: 'GET', path: '/api/instagram/discover', description: 'AI-filtered influencer/account discovery', price: '0.03 USDC' },
   ],
   pricing: {
     amount: process.env.PRICE_USDC || '0.005',
@@ -128,7 +140,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/instagram/discover'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/scrapers/instagram-scraper.ts
+++ b/src/scrapers/instagram-scraper.ts
@@ -55,6 +55,32 @@ export interface AIAnalysis {
 
 export interface FullAnalysis { profile: InstagramProfile; posts: InstagramPost[]; ai_analysis: AIAnalysis; }
 
+export interface DiscoverFilters {
+  niche?: string;
+  account_type?: string;
+  sentiment?: string;
+  min_followers?: number;
+  max_followers?: number;
+  brand_safe?: boolean;
+  limit?: number;
+}
+
+export interface DiscoverResult {
+  accounts: Array<{
+    username: string;
+    followers: number;
+    engagement_rate: number;
+    account_type: string;
+    niche: string;
+    sentiment: string;
+    brand_safety_score: number;
+    match_reasons: string[];
+  }>;
+  scanned: number;
+  returned: number;
+  partial_failures: string[];
+}
+
 // ─── Helpers ────────────────────────────────────────
 
 function cleanText(s: string): string {
@@ -224,20 +250,33 @@ const VISION_PROMPT = `Analyze these Instagram post images from a single account
 Return ONLY valid JSON, no markdown.`;
 
 async function analyzeWithVision(imageUrls: string[], captions: string[], profileSummary: string): Promise<any> {
-  // Try OpenAI GPT-4o first, then Claude
-  const openaiKey = process.env.OPENAI_API_KEY;
+  const provider = (process.env.VISION_PROVIDER || 'openai-compatible').toLowerCase();
+  const visionApiKey = process.env.VISION_API_KEY || process.env.OPENAI_API_KEY;
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
-  
-  if (openaiKey) {
-    return analyzeOpenAI(openaiKey, imageUrls, captions, profileSummary);
-  } else if (anthropicKey) {
+
+  if ((provider === 'openai' || provider === 'openai-compatible') && visionApiKey) {
+    return analyzeOpenAICompatible(visionApiKey, imageUrls, captions, profileSummary);
+  }
+
+  if (provider === 'anthropic' && anthropicKey) {
     return analyzeClaude(anthropicKey, imageUrls, captions, profileSummary);
   }
+
+  if (visionApiKey) {
+    return analyzeOpenAICompatible(visionApiKey, imageUrls, captions, profileSummary);
+  }
+
+  if (anthropicKey) {
+    return analyzeClaude(anthropicKey, imageUrls, captions, profileSummary);
+  }
+
   // Fallback: heuristic analysis without vision model
   return heuristicAnalysis(captions, profileSummary);
 }
 
-async function analyzeOpenAI(apiKey: string, imageUrls: string[], captions: string[], profileSummary: string): Promise<any> {
+async function analyzeOpenAICompatible(apiKey: string, imageUrls: string[], captions: string[], profileSummary: string): Promise<any> {
+  const baseUrl = (process.env.VISION_BASE_URL || 'https://api.openai.com/v1').replace(/\/$/, '');
+  const model = process.env.VISION_MODEL || 'gpt-4o';
   const content: any[] = [
     { type: 'text', text: `${VISION_PROMPT}\n\nProfile: ${profileSummary}\n\nCaptions:\n${captions.map((c, i) => `${i + 1}. ${c.slice(0, 200)}`).join('\n')}` },
   ];
@@ -245,15 +284,15 @@ async function analyzeOpenAI(apiKey: string, imageUrls: string[], captions: stri
   for (const url of imageUrls.slice(0, 6)) {
     content.push({ type: 'image_url', image_url: { url, detail: 'low' } });
   }
-  const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+  const resp = await fetch(`${baseUrl}/chat/completions`, {
     method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
-    body: JSON.stringify({ model: 'gpt-4o', messages: [{ role: 'user', content }], max_tokens: 1500, temperature: 0.3 }),
+    body: JSON.stringify({ model, messages: [{ role: 'user', content }], max_tokens: 1500, temperature: 0.3 }),
   });
-  if (!resp.ok) throw new Error(`OpenAI API error: ${resp.status}`);
+  if (!resp.ok) throw new Error(`Vision API error: ${resp.status}`);
   const data = await resp.json();
   const text = data.choices?.[0]?.message?.content || '';
-  try { return { ...JSON.parse(text.replace(/```json?\n?/g, '').replace(/```/g, '').trim()), model_used: 'gpt-4o' }; }
-  catch { return { ...heuristicAnalysis(captions, profileSummary), model_used: 'gpt-4o-fallback' }; }
+  try { return { ...JSON.parse(text.replace(/```json?\n?/g, '').replace(/```/g, '').trim()), model_used: model }; }
+  catch { return { ...heuristicAnalysis(captions, profileSummary), model_used: `${model}-fallback` }; }
 }
 
 async function analyzeClaude(apiKey: string, imageUrls: string[], captions: string[], profileSummary: string): Promise<any> {
@@ -359,4 +398,73 @@ export async function analyzeImages(username: string): Promise<{ images_analyzed
 export async function auditProfile(username: string): Promise<{ profile: InstagramProfile; authenticity: AuthenticityAnalysis }> {
   const full = await analyzeProfile(username);
   return { profile: full.profile, authenticity: full.ai_analysis.authenticity };
+}
+
+
+function parseSeedUsernames(): string[] {
+  const raw = process.env.IG_DISCOVER_SEED_USERNAMES || '';
+  return raw.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function includesValue(target: string | undefined, expected: string | undefined): boolean {
+  if (!expected) return true;
+  return (target || '').toLowerCase().includes(expected.toLowerCase());
+}
+
+export async function discoverAccounts(filters: DiscoverFilters): Promise<DiscoverResult> {
+  const limit = Math.min(Math.max(filters.limit || 10, 1), 25);
+  const seeds = parseSeedUsernames().slice(0, 50);
+  if (!seeds.length) {
+    throw new Error('IG_DISCOVER_SEED_USERNAMES is empty. Add comma-separated public usernames in env.');
+  }
+
+  const accounts: DiscoverResult['accounts'] = [];
+  const partial_failures: string[] = [];
+
+  for (const username of seeds) {
+    try {
+      const full = await analyzeProfile(username);
+      const { profile, ai_analysis } = full;
+      const reasons: string[] = [];
+
+      const niche = ai_analysis.account_type?.niche || ai_analysis.content_themes?.top_themes?.[0] || 'unknown';
+      const accountType = ai_analysis.account_type?.primary || 'unknown';
+      const sentiment = ai_analysis.sentiment?.overall || 'neutral';
+      const safety = ai_analysis.content_themes?.brand_safety_score || 0;
+
+      if (filters.min_followers != null && profile.followers < filters.min_followers) continue;
+      if (filters.max_followers != null && profile.followers > filters.max_followers) continue;
+      if (filters.brand_safe === true && safety < 70) continue;
+      if (!includesValue(niche, filters.niche)) continue;
+      if (!includesValue(accountType, filters.account_type)) continue;
+      if (!includesValue(sentiment, filters.sentiment)) continue;
+
+      if (filters.niche) reasons.push(`niche:${niche}`);
+      if (filters.account_type) reasons.push(`type:${accountType}`);
+      if (filters.sentiment) reasons.push(`sentiment:${sentiment}`);
+      if (filters.brand_safe) reasons.push(`brand_safety:${safety}`);
+
+      accounts.push({
+        username: profile.username,
+        followers: profile.followers,
+        engagement_rate: profile.engagement_rate,
+        account_type: accountType,
+        niche,
+        sentiment,
+        brand_safety_score: safety,
+        match_reasons: reasons.length ? reasons : ['matched'],
+      });
+
+      if (accounts.length >= limit) break;
+    } catch (err: any) {
+      partial_failures.push(`${username}: ${err?.message || String(err)}`);
+    }
+  }
+
+  return {
+    accounts,
+    scanned: seeds.length,
+    returned: accounts.length,
+    partial_failures,
+  };
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -27,7 +27,7 @@ import {
   searchLinkedInPeople, 
   findCompanyEmployees 
 } from './scrapers/linkedin-enrichment';
-import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile } from './scrapers/instagram-scraper';
+import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile, discoverAccounts } from './scrapers/instagram-scraper';
 import { searchReddit, getSubreddit, getTrending, getComments } from './scrapers/reddit-scraper';
 
 export const serviceRouter = new Hono();
@@ -1016,6 +1016,7 @@ const IG_POSTS_PRICE    = 0.02;   // $0.02 per posts fetch
 const IG_ANALYZE_PRICE  = 0.15;   // $0.15 per full analysis (includes AI vision)
 const IG_IMAGES_PRICE   = 0.08;   // $0.08 per image-only analysis
 const IG_AUDIT_PRICE    = 0.05;   // $0.05 per authenticity audit
+const IG_DISCOVER_PRICE = 0.03;   // $0.03 per AI-filtered account discovery
 
 // ─── GET /api/instagram/profile/:username ───────────
 
@@ -1248,6 +1249,105 @@ serviceRouter.get('/instagram/audit/:username', async (c) => {
     });
   } catch (err: any) {
     return c.json({ error: 'Instagram audit failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ─── GET /api/instagram/discover ─────────────────────
+
+serviceRouter.get('/instagram/discover', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/instagram/discover', 'Discover Instagram accounts by AI-derived filters: niche, account_type, sentiment, brand safety, followers', IG_DISCOVER_PRICE, walletAddress, {
+      input: {
+        niche: 'string (optional) — e.g. travel, fitness, fashion',
+        account_type: 'string (optional) — influencer, business, personal, bot_fake, meme_page, news_media',
+        type: 'string (optional alias for account_type)',
+        sentiment: 'string (optional) — positive, neutral, negative, mixed',
+        min_followers: 'number (optional)',
+        max_followers: 'number (optional)',
+        brand_safe: 'boolean (optional) — true to keep only safety score >= 70',
+        limit: 'number (optional, default: 10, max: 25)',
+      },
+      output: {
+        accounts: '[{ username, followers, engagement_rate, account_type, niche, sentiment, brand_safety_score, match_reasons[] }]',
+        scanned: 'number',
+        returned: 'number',
+        partial_failures: 'string[]',
+      },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, IG_DISCOVER_PRICE);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const clientIp = c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (!checkProxyRateLimit(clientIp)) {
+    c.header('Retry-After', '60');
+    return c.json({ error: 'Proxy rate limit exceeded. Max 20 requests/min to protect proxy quota.', retryAfter: 60 }, 429);
+  }
+
+  const toNumber = (value: string | undefined): number | undefined => {
+    if (value == null || value === '') return undefined;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  };
+
+  const parseBool = (value: string | undefined): boolean | undefined => {
+    if (value == null || value === '') return undefined;
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'n'].includes(normalized)) return false;
+    return undefined;
+  };
+
+  const minFollowers = toNumber(c.req.query('min_followers'));
+  const maxFollowers = toNumber(c.req.query('max_followers'));
+  const limit = toNumber(c.req.query('limit'));
+  const brandSafe = parseBool(c.req.query('brand_safe'));
+
+  if (Number.isNaN(minFollowers) || Number.isNaN(maxFollowers) || Number.isNaN(limit)) {
+    return c.json({ error: 'Invalid numeric filters. Use numbers for min_followers, max_followers, and limit.' }, 400);
+  }
+  if (minFollowers != null && minFollowers < 0) return c.json({ error: 'min_followers must be >= 0' }, 400);
+  if (maxFollowers != null && maxFollowers < 0) return c.json({ error: 'max_followers must be >= 0' }, 400);
+  if (minFollowers != null && maxFollowers != null && minFollowers > maxFollowers) {
+    return c.json({ error: 'min_followers cannot be greater than max_followers' }, 400);
+  }
+  if (limit != null && (limit < 1 || limit > 25)) return c.json({ error: 'limit must be between 1 and 25' }, 400);
+  if (c.req.query('brand_safe') && brandSafe == null) {
+    return c.json({ error: 'brand_safe must be true/false (or 1/0)' }, 400);
+  }
+
+  const filters = {
+    niche: c.req.query('niche') || undefined,
+    account_type: c.req.query('account_type') || c.req.query('type') || undefined,
+    sentiment: c.req.query('sentiment') || undefined,
+    min_followers: minFollowers,
+    max_followers: maxFollowers,
+    brand_safe: brandSafe,
+    limit: limit != null ? Math.floor(limit) : undefined,
+  };
+
+  try {
+    const proxy = getProxy();
+    const result = await discoverAccounts(filters);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      ...result,
+      meta: {
+        filters,
+        proxy: { country: proxy.country, type: 'mobile' },
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'Instagram discover failed', message: err?.message || String(err) }, 502);
   }
 });
 

--- a/tests/instagram-discover-endpoints.test.ts
+++ b/tests/instagram-discover-endpoints.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x1111111111111111111111111111111111111111';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_03 = '0x0000000000000000000000000000000000000000000000000000000000007530';
+
+let txCounter = 1000;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function installPaymentFetchMock(recipientAddress: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      const payload = init?.body ? JSON.parse(String(init.body)) : {};
+      if (payload?.method !== 'eth_getTransactionReceipt') {
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(recipientAddress),
+            ],
+            data: USDC_AMOUNT_0_03,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('Instagram discover endpoint', () => {
+  test('GET /api/instagram/discover returns 402 with x402 payload when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/instagram/discover?niche=travel'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/instagram/discover');
+    expect(body.price.amount).toBe('0.03');
+    expect(body.message).toBe('Payment required');
+  });
+
+  test('GET /api/instagram/discover validates numeric filters after payment verification', async () => {
+    const calls = installPaymentFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/instagram/discover?min_followers=abc', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(calls.some((url) => url.includes('mainnet.base.org'))).toBe(true);
+    expect(res.status).toBe(400);
+
+    const body = await res.json() as any;
+    expect(body.error).toContain('Invalid numeric filters');
+  });
+});


### PR DESCRIPTION
## Summary
This PR finishes the remaining Instagram bounty surface by wiring a production route for account discovery and hardening vision provider config behavior.

### ✅ What was added
- Added `GET /api/instagram/discover` in `src/service.ts`
  - x402 payment gate (`$0.03`)
  - supports filters:
    - `niche`
    - `account_type` (alias `type`)
    - `sentiment`
    - `min_followers`
    - `max_followers`
    - `brand_safe`
    - `limit` (1..25)
  - strict validation for numeric/boolean filters
  - returns `accounts + scanned + returned + partial_failures`
  - includes mobile-proxy metadata and settled payment metadata
- Imported and integrated `discoverAccounts` from `instagram-scraper.ts`
- Added optional env docs in `.env.example`:
  - `VISION_PROVIDER`, `VISION_API_KEY`, `VISION_BASE_URL`, `VISION_MODEL`, `ANTHROPIC_API_KEY`
  - `IG_DISCOVER_SEED_USERNAMES`
- Updated discovery/health endpoint listings in `src/index.ts`

### ✅ Tests
Added `tests/instagram-discover-endpoints.test.ts`:
- 402 schema response when payment is missing
- paid request path reaches input validation and rejects invalid numeric filters

### ✅ Local verification
- `bun test` (6 passed)
- `bun run typecheck` (tsc --noEmit)

## Notes
- `/discover` intentionally uses a seed list (`IG_DISCOVER_SEED_USERNAMES`) for deterministic and bounded discovery workload.
- Keeps existing Instagram profile/posts/analyze/audit contract unchanged.

Ref: #71
