### PR TITLE
feat: add App Store Intelligence API to /api/run

### DIFF
--- a/src/scrapers/app-store-scraper.ts
+++ b/src/scrapers/app-store-scraper.ts
@@ -1,0 +1,584 @@
+import { proxyFetch } from '../proxy';
+
+export type AppStoreName = 'apple' | 'google';
+
+export const SUPPORTED_APP_COUNTRIES = ['US', 'DE', 'FR', 'ES', 'GB', 'PL'] as const;
+
+type SupportedCountry = typeof SUPPORTED_APP_COUNTRIES[number];
+
+export interface AppRankingItem {
+  rank: number;
+  appName: string;
+  developer: string | null;
+  appId: string;
+  rating: number | null;
+  ratingCount: number | null;
+  price: string;
+  inAppPurchases: boolean | null;
+  category: string | null;
+  lastUpdated: string | null;
+  size: string | null;
+  icon: string | null;
+}
+
+export interface AppReview {
+  rating: number | null;
+  title: string;
+  text: string;
+  date: string | null;
+  reviewer: string | null;
+}
+
+export interface AppStoreResult {
+  type: 'rankings' | 'app' | 'search' | 'trending';
+  store: AppStoreName;
+  country: SupportedCountry;
+  timestamp: string;
+  category?: string;
+  query?: string;
+  appId?: string;
+  rankings?: AppRankingItem[];
+  app?: AppRankingItem;
+  reviews?: AppReview[];
+  results?: AppRankingItem[];
+  metadata: {
+    totalRanked?: number;
+    totalResults?: number;
+    scrapedAt: string;
+    source: string;
+  };
+}
+
+const APPLE_GENRE_MAP: Record<string, string> = {
+  games: '6014',
+  business: '6000',
+  finance: '6015',
+  health: '6013',
+  lifestyle: '6012',
+  productivity: '6007',
+  social: '6005',
+  travel: '6003',
+  utilities: '6002',
+};
+
+const GOOGLE_CATEGORY_MAP: Record<string, string> = {
+  games: 'GAME',
+  business: 'BUSINESS',
+  finance: 'FINANCE',
+  health: 'HEALTH_AND_FITNESS',
+  lifestyle: 'LIFESTYLE',
+  productivity: 'PRODUCTIVITY',
+  social: 'SOCIAL',
+  travel: 'TRAVEL_AND_LOCAL',
+  utilities: 'TOOLS',
+};
+
+function ensureCountry(country: string): SupportedCountry {
+  const normalized = country.trim().toUpperCase();
+  if (!SUPPORTED_APP_COUNTRIES.includes(normalized as SupportedCountry)) {
+    throw new Error(`Unsupported country: ${country}. Supported countries: ${SUPPORTED_APP_COUNTRIES.join(', ')}`);
+  }
+  return normalized as SupportedCountry;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/[,_\s]/g, '');
+    const parsed = Number(cleaned);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function parseTextMatch(html: string, patterns: RegExp[]): string | null {
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match && typeof match[1] === 'string' && match[1].trim().length > 0) {
+      return decodeHtml(match[1].trim());
+    }
+  }
+  return null;
+}
+
+function decodeHtml(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function normalizePrice(value: unknown): string {
+  if (typeof value === 'number') return value <= 0 ? 'Free' : `$${value.toFixed(2)}`;
+  if (typeof value === 'string') {
+    if (value.trim().length === 0) return 'Unknown';
+    const asNum = toNumber(value);
+    if (asNum === null) return value;
+    return asNum <= 0 ? 'Free' : `$${asNum.toFixed(2)}`;
+  }
+  return 'Unknown';
+}
+
+async function fetchAppleLookupByIds(country: SupportedCountry, ids: string[]): Promise<Map<string, any>> {
+  if (ids.length === 0) return new Map();
+
+  const lookupUrl = `https://itunes.apple.com/lookup?id=${ids.join(',')}&country=${country}&entity=software`;
+  const response = await proxyFetch(lookupUrl, {
+    timeoutMs: 25_000,
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) return new Map();
+  const payload = await response.json() as { results?: any[] };
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+
+  const map = new Map<string, any>();
+  for (const row of results) {
+    if (row && typeof row.trackId !== 'undefined') {
+      map.set(String(row.trackId), row);
+      if (typeof row.bundleId === 'string') {
+        map.set(row.bundleId, row);
+      }
+    }
+  }
+
+  return map;
+}
+
+async function fetchAppleReviews(trackId: string, country: SupportedCountry, limit = 10): Promise<AppReview[]> {
+  const countryLower = country.toLowerCase();
+  const url = `https://itunes.apple.com/${countryLower}/rss/customerreviews/id=${encodeURIComponent(trackId)}/sortBy=mostRecent/json`;
+
+  try {
+    const response = await proxyFetch(url, {
+      timeoutMs: 25_000,
+      headers: { Accept: 'application/json' },
+      maxRetries: 1,
+    });
+
+    if (!response.ok) return [];
+    const payload = await response.json() as any;
+    const entries = Array.isArray(payload?.feed?.entry) ? payload.feed.entry.slice(1) : [];
+
+    return entries.slice(0, limit).map((entry: any) => ({
+      rating: toNumber(entry?.['im:rating']?.label),
+      title: typeof entry?.title?.label === 'string' ? entry.title.label : 'Untitled',
+      text: typeof entry?.content?.label === 'string' ? entry.content.label : '',
+      date: typeof entry?.updated?.label === 'string' ? entry.updated.label : null,
+      reviewer: typeof entry?.author?.name?.label === 'string' ? entry.author.name.label : null,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function appleRankings(category: string, country: SupportedCountry, limit: number): Promise<AppStoreResult> {
+  const genre = APPLE_GENRE_MAP[category.toLowerCase()] || APPLE_GENRE_MAP.games;
+  const url = `https://itunes.apple.com/${country.toLowerCase()}/rss/topfreeapplications/limit=${limit}/genre=${genre}/json`;
+
+  const response = await proxyFetch(url, {
+    timeoutMs: 30_000,
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Apple rankings fetch failed: HTTP ${response.status}`);
+  }
+
+  const payload = await response.json() as any;
+  const entries = Array.isArray(payload?.feed?.entry) ? payload.feed.entry : [];
+
+  const ids = entries
+    .map((entry: any) => String(entry?.id?.attributes?.['im:id'] || ''))
+    .filter((id: string) => id.length > 0)
+    .slice(0, Math.min(limit, 50));
+
+  const lookup = await fetchAppleLookupByIds(country, ids);
+
+  const rankings: AppRankingItem[] = entries.slice(0, limit).map((entry: any, idx: number) => {
+    const trackId = String(entry?.id?.attributes?.['im:id'] || '');
+    const lookedUp = lookup.get(trackId);
+
+    return {
+      rank: idx + 1,
+      appName: typeof entry?.['im:name']?.label === 'string' ? entry['im:name'].label : 'Unknown App',
+      developer: typeof entry?.['im:artist']?.label === 'string' ? entry['im:artist'].label : null,
+      appId: (lookedUp?.bundleId as string | undefined) || trackId,
+      rating: toNumber(lookedUp?.averageUserRating),
+      ratingCount: toNumber(lookedUp?.userRatingCount),
+      price: normalizePrice(lookedUp?.price ?? entry?.['im:price']?.attributes?.amount),
+      inAppPurchases: typeof lookedUp?.features === 'string'
+        ? lookedUp.features.toLowerCase().includes('in-app')
+        : null,
+      category: typeof entry?.category?.attributes?.label === 'string' ? entry.category.attributes.label : null,
+      lastUpdated: typeof lookedUp?.currentVersionReleaseDate === 'string' ? lookedUp.currentVersionReleaseDate : null,
+      size: lookedUp?.fileSizeBytes ? `${Math.round(Number(lookedUp.fileSizeBytes) / (1024 * 1024))} MB` : null,
+      icon: typeof entry?.['im:image']?.[2]?.label === 'string'
+        ? entry['im:image'][2].label
+        : (typeof lookedUp?.artworkUrl512 === 'string' ? lookedUp.artworkUrl512 : null),
+    };
+  });
+
+  return {
+    type: 'rankings',
+    store: 'apple',
+    country,
+    category,
+    timestamp: new Date().toISOString(),
+    rankings,
+    metadata: {
+      totalRanked: rankings.length,
+      scrapedAt: new Date().toISOString(),
+      source: 'itunes-rss+lookup',
+    },
+  };
+}
+
+async function appleSearch(query: string, country: SupportedCountry, limit: number): Promise<AppStoreResult> {
+  const url = `https://itunes.apple.com/search?term=${encodeURIComponent(query)}&country=${country}&entity=software&limit=${limit}`;
+
+  const response = await proxyFetch(url, {
+    timeoutMs: 25_000,
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Apple search failed: HTTP ${response.status}`);
+  }
+
+  const payload = await response.json() as { results?: any[] };
+  const rows = Array.isArray(payload?.results) ? payload.results : [];
+
+  const results: AppRankingItem[] = rows.map((row, idx) => ({
+    rank: idx + 1,
+    appName: typeof row?.trackName === 'string' ? row.trackName : 'Unknown App',
+    developer: typeof row?.sellerName === 'string' ? row.sellerName : null,
+    appId: typeof row?.bundleId === 'string' ? row.bundleId : String(row?.trackId || ''),
+    rating: toNumber(row?.averageUserRating),
+    ratingCount: toNumber(row?.userRatingCount),
+    price: normalizePrice(row?.price),
+    inAppPurchases: Array.isArray(row?.features) ? row.features.some((f: unknown) => String(f).toLowerCase().includes('in-app')) : null,
+    category: typeof row?.primaryGenreName === 'string' ? row.primaryGenreName : null,
+    lastUpdated: typeof row?.currentVersionReleaseDate === 'string' ? row.currentVersionReleaseDate : null,
+    size: typeof row?.fileSizeBytes === 'string' ? `${Math.round(Number(row.fileSizeBytes) / (1024 * 1024))} MB` : null,
+    icon: typeof row?.artworkUrl512 === 'string' ? row.artworkUrl512 : null,
+  }));
+
+  return {
+    type: 'search',
+    store: 'apple',
+    country,
+    query,
+    timestamp: new Date().toISOString(),
+    results,
+    metadata: {
+      totalResults: results.length,
+      scrapedAt: new Date().toISOString(),
+      source: 'itunes-search',
+    },
+  };
+}
+
+async function appleApp(appId: string, country: SupportedCountry): Promise<AppStoreResult> {
+  const byBundleUrl = `https://itunes.apple.com/lookup?bundleId=${encodeURIComponent(appId)}&country=${country}`;
+  let response = await proxyFetch(byBundleUrl, {
+    timeoutMs: 25_000,
+    headers: { Accept: 'application/json' },
+    maxRetries: 1,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Apple app lookup failed: HTTP ${response.status}`);
+  }
+
+  let payload = await response.json() as { results?: any[] };
+  let row = Array.isArray(payload?.results) && payload.results.length > 0 ? payload.results[0] : null;
+
+  if (!row && /^\d+$/.test(appId)) {
+    const byTrackUrl = `https://itunes.apple.com/lookup?id=${encodeURIComponent(appId)}&country=${country}`;
+    response = await proxyFetch(byTrackUrl, {
+      timeoutMs: 25_000,
+      headers: { Accept: 'application/json' },
+      maxRetries: 1,
+    });
+
+    if (response.ok) {
+      payload = await response.json() as { results?: any[] };
+      row = Array.isArray(payload?.results) && payload.results.length > 0 ? payload.results[0] : null;
+    }
+  }
+
+  if (!row) {
+    throw new Error(`Apple app not found for appId=${appId}`);
+  }
+
+  const trackId = String(row.trackId || appId);
+  const reviews = await fetchAppleReviews(trackId, country, 10);
+
+  const app: AppRankingItem = {
+    rank: 1,
+    appName: typeof row.trackName === 'string' ? row.trackName : 'Unknown App',
+    developer: typeof row.sellerName === 'string' ? row.sellerName : null,
+    appId: typeof row.bundleId === 'string' ? row.bundleId : trackId,
+    rating: toNumber(row.averageUserRating),
+    ratingCount: toNumber(row.userRatingCount),
+    price: normalizePrice(row.price),
+    inAppPurchases: Array.isArray(row.features) ? row.features.some((f: unknown) => String(f).toLowerCase().includes('in-app')) : null,
+    category: typeof row.primaryGenreName === 'string' ? row.primaryGenreName : null,
+    lastUpdated: typeof row.currentVersionReleaseDate === 'string' ? row.currentVersionReleaseDate : null,
+    size: typeof row.fileSizeBytes === 'string' ? `${Math.round(Number(row.fileSizeBytes) / (1024 * 1024))} MB` : null,
+    icon: typeof row.artworkUrl512 === 'string' ? row.artworkUrl512 : null,
+  };
+
+  return {
+    type: 'app',
+    store: 'apple',
+    country,
+    appId,
+    timestamp: new Date().toISOString(),
+    app,
+    reviews,
+    metadata: {
+      scrapedAt: new Date().toISOString(),
+      source: 'itunes-lookup+reviews',
+    },
+  };
+}
+
+function parseGoogleCards(html: string, categoryLabel?: string): AppRankingItem[] {
+  const cards = Array.from(html.matchAll(/\/store\/apps\/details\?id=([A-Za-z0-9._-]+)[\s\S]{0,220}?aria-label="([^"]+)"[\s\S]{0,400}?(?:\/store\/apps\/dev\?id=[^"]+">([^<]+)<)?/g));
+  const output: AppRankingItem[] = [];
+
+  for (const [idx, card] of cards.entries()) {
+    const appId = card[1];
+    const rawLabel = decodeHtml(card[2]);
+    const developer = card[3] ? decodeHtml(card[3]) : null;
+
+    const appName = rawLabel
+      .replace(/^Install\s+/i, '')
+      .replace(/^Download\s+/i, '')
+      .replace(/\s+on\s+Google\s+Play.*$/i, '')
+      .trim() || appId;
+
+    output.push({
+      rank: idx + 1,
+      appName,
+      developer,
+      appId,
+      rating: null,
+      ratingCount: null,
+      price: 'Free',
+      inAppPurchases: null,
+      category: categoryLabel || null,
+      lastUpdated: null,
+      size: null,
+      icon: null,
+    });
+  }
+
+  // Deduplicate by app id while preserving order.
+  const deduped = new Map<string, AppRankingItem>();
+  for (const item of output) {
+    if (!deduped.has(item.appId)) {
+      deduped.set(item.appId, item);
+    }
+  }
+
+  return Array.from(deduped.values());
+}
+
+async function googleRankings(category: string, country: SupportedCountry, limit: number, type: 'rankings' | 'trending'): Promise<AppStoreResult> {
+  const categoryCode = GOOGLE_CATEGORY_MAP[category.toLowerCase()] || GOOGLE_CATEGORY_MAP.games;
+  const collection = type === 'trending' ? 'topselling_new_free' : 'topselling_free';
+  const url = `https://play.google.com/store/apps/collection/${collection}?hl=en&gl=${country}&category=${categoryCode}`;
+
+  const response = await proxyFetch(url, {
+    timeoutMs: 30_000,
+    headers: { Accept: 'text/html' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google ${type} fetch failed: HTTP ${response.status}`);
+  }
+
+  const html = await response.text();
+  const rankings = parseGoogleCards(html, category).slice(0, limit).map((item, idx) => ({
+    ...item,
+    rank: idx + 1,
+  }));
+
+  return {
+    type,
+    store: 'google',
+    country,
+    category,
+    timestamp: new Date().toISOString(),
+    rankings,
+    metadata: {
+      totalRanked: rankings.length,
+      scrapedAt: new Date().toISOString(),
+      source: `google-play-${collection}`,
+    },
+  };
+}
+
+async function googleSearch(query: string, country: SupportedCountry, limit: number): Promise<AppStoreResult> {
+  const url = `https://play.google.com/store/search?q=${encodeURIComponent(query)}&c=apps&hl=en&gl=${country}`;
+
+  const response = await proxyFetch(url, {
+    timeoutMs: 30_000,
+    headers: { Accept: 'text/html' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google search failed: HTTP ${response.status}`);
+  }
+
+  const html = await response.text();
+  const results = parseGoogleCards(html).slice(0, limit).map((item, idx) => ({
+    ...item,
+    rank: idx + 1,
+  }));
+
+  return {
+    type: 'search',
+    store: 'google',
+    country,
+    query,
+    timestamp: new Date().toISOString(),
+    results,
+    metadata: {
+      totalResults: results.length,
+      scrapedAt: new Date().toISOString(),
+      source: 'google-play-search',
+    },
+  };
+}
+
+async function googleApp(appId: string, country: SupportedCountry): Promise<AppStoreResult> {
+  const url = `https://play.google.com/store/apps/details?id=${encodeURIComponent(appId)}&hl=en&gl=${country}`;
+
+  const response = await proxyFetch(url, {
+    timeoutMs: 30_000,
+    headers: { Accept: 'text/html' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google app detail fetch failed: HTTP ${response.status}`);
+  }
+
+  const html = await response.text();
+
+  const name = parseTextMatch(html, [
+    /<h1[^>]*>\s*<span[^>]*>([^<]+)<\/span>/i,
+    /"name"\s*:\s*"([^"]+)"/i,
+  ]) || appId;
+
+  const developer = parseTextMatch(html, [
+    /\/store\/apps\/dev\?id=[^"']+["'][^>]*>([^<]+)<\/a>/i,
+    /"author"\s*:\s*\[\{"@type":"Organization","name":"([^"]+)"/i,
+  ]);
+
+  const category = parseTextMatch(html, [
+    /\/store\/apps\/category\/([A-Z_]+)["']/i,
+  ]);
+
+  const ratingRaw = parseTextMatch(html, [
+    /itemprop="ratingValue"\s+content="([0-9.]+)"/i,
+    /"ratingValue"\s*:\s*"([0-9.]+)"/i,
+  ]);
+
+  const ratingCountRaw = parseTextMatch(html, [
+    /itemprop="ratingCount"\s+content="([0-9,\.]+)"/i,
+    /"ratingCount"\s*:\s*"([0-9,\.]+)"/i,
+  ]);
+
+  const icon = parseTextMatch(html, [
+    /itemprop="image"\s+content="([^"]+)"/i,
+    /<img[^>]+src="([^"]+)"[^>]+alt="[^"]*"[^>]*>/i,
+  ]);
+
+  const updated = parseTextMatch(html, [
+    /Updated on<\/div>\s*<div[^>]*><span[^>]*>([^<]+)<\/span>/i,
+  ]);
+
+  const size = parseTextMatch(html, [
+    /Size<\/div>\s*<div[^>]*><span[^>]*>([^<]+)<\/span>/i,
+  ]);
+
+  const app: AppRankingItem = {
+    rank: 1,
+    appName: name,
+    developer,
+    appId,
+    rating: toNumber(ratingRaw),
+    ratingCount: toNumber(ratingCountRaw),
+    price: 'Free',
+    inAppPurchases: /In-app purchases/i.test(html),
+    category: category ? category.replace(/_/g, ' ') : null,
+    lastUpdated: updated,
+    size,
+    icon,
+  };
+
+  return {
+    type: 'app',
+    store: 'google',
+    country,
+    appId,
+    timestamp: new Date().toISOString(),
+    app,
+    reviews: [],
+    metadata: {
+      scrapedAt: new Date().toISOString(),
+      source: 'google-play-details',
+    },
+  };
+}
+
+export async function getAppStoreData(params: {
+  type: 'rankings' | 'app' | 'search' | 'trending';
+  store: AppStoreName;
+  country: string;
+  category?: string;
+  query?: string;
+  appId?: string;
+  limit?: number;
+}): Promise<AppStoreResult> {
+  const country = ensureCountry(params.country);
+  const category = (params.category || 'games').trim().toLowerCase();
+  const limit = Math.max(1, Math.min(params.limit || 20, 50));
+
+  if (params.store === 'apple') {
+    if (params.type === 'rankings') return appleRankings(category, country, limit);
+    if (params.type === 'trending') {
+      const ranking = await appleRankings(category, country, limit);
+      return { ...ranking, type: 'trending' };
+    }
+    if (params.type === 'search') {
+      if (!params.query) throw new Error('Missing query parameter for Apple search');
+      return appleSearch(params.query, country, limit);
+    }
+    if (params.type === 'app') {
+      if (!params.appId) throw new Error('Missing appId parameter for Apple app details');
+      return appleApp(params.appId, country);
+    }
+  }
+
+  if (params.store === 'google') {
+    if (params.type === 'rankings') return googleRankings(category, country, limit, 'rankings');
+    if (params.type === 'trending') return googleRankings(category, country, limit, 'trending');
+    if (params.type === 'search') {
+      if (!params.query) throw new Error('Missing query parameter for Google search');
+      return googleSearch(params.query, country, limit);
+    }
+    if (params.type === 'app') {
+      if (!params.appId) throw new Error('Missing appId parameter for Google app details');
+      return googleApp(params.appId, country);
+    }
+  }
+
+  throw new Error(`Unsupported app intelligence request: type=${params.type} store=${params.store}`);
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,6 +29,7 @@ import {
 } from './scrapers/linkedin-enrichment';
 import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile } from './scrapers/instagram-scraper';
 import { searchReddit, getSubreddit, getTrending, getComments } from './scrapers/reddit-scraper';
+import { getAppStoreData, SUPPORTED_APP_COUNTRIES } from './scrapers/app-store-scraper';
 
 export const serviceRouter = new Hono();
 
@@ -41,6 +42,9 @@ const PRICE_USDC = 0.005;
 const DESCRIPTION = 'Job Market Intelligence API (Indeed/LinkedIn): title, company, location, salary, date, link, remote + proxy exit metadata.';
 const MAPS_PRICE_USDC = 0.005;
 const MAPS_DESCRIPTION = 'Extract structured business data from Google Maps: name, address, phone, website, email, hours, ratings, reviews, categories, and geocoordinates. Search by category + location with full pagination.';
+const APP_STORE_PRICE_USDC = 0.02;
+const APP_STORE_DESCRIPTION = 'App Store Intelligence API: rankings, app metadata + reviews, keyword search, and trending apps for Apple App Store and Google Play.';
+const APP_STORE_TYPES = new Set(['rankings', 'app', 'search', 'trending']);
 
 const MAPS_OUTPUT_SCHEMA = {
   input: {
@@ -74,6 +78,27 @@ const MAPS_OUTPUT_SCHEMA = {
   },
 };
 
+const APP_STORE_OUTPUT_SCHEMA = {
+  input: {
+    type: '"rankings" | "app" | "search" | "trending" (required)',
+    store: '"apple" | "google" (required)',
+    country: `string — one of ${SUPPORTED_APP_COUNTRIES.join(', ')} (required)`,
+    category: 'string (optional; rankings/trending, default: games)',
+    appId: 'string (required when type=app)',
+    query: 'string (required when type=search)',
+    limit: 'number (optional, default 20, max 50)',
+  },
+  output: {
+    rankings: 'AppRankingItem[] (rankings/trending)',
+    app: 'AppRankingItem (app details)',
+    reviews: 'AppReview[] (app details)',
+    results: 'AppRankingItem[] (search)',
+    metadata: '{ totalRanked|totalResults, scrapedAt, source }',
+    proxy: '{ country: string, type: "mobile" }',
+    payment: '{ txHash, network, amount, settled }',
+  },
+};
+
 async function getProxyExitIp(): Promise<string | null> {
   try {
     const r = await proxyFetch('https://api.ipify.org?format=json', {
@@ -95,15 +120,32 @@ serviceRouter.get('/run', async (c) => {
     return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
   }
 
+  const requestedType = (c.req.query('type') || 'maps').toLowerCase();
+  const isMapsRequest = requestedType === 'maps';
+  const isAppStoreRequest = APP_STORE_TYPES.has(requestedType);
+
+  if (!isMapsRequest && !isAppStoreRequest) {
+    return c.json({
+      error: 'Invalid type. Use maps (default), rankings, app, search, or trending',
+    }, 400);
+  }
+
   const payment = extractPayment(c);
   if (!payment) {
     return c.json(
-      build402Response('/api/run', MAPS_DESCRIPTION, MAPS_PRICE_USDC, walletAddress, MAPS_OUTPUT_SCHEMA),
+      build402Response(
+        '/api/run',
+        isAppStoreRequest ? APP_STORE_DESCRIPTION : MAPS_DESCRIPTION,
+        isAppStoreRequest ? APP_STORE_PRICE_USDC : MAPS_PRICE_USDC,
+        walletAddress,
+        isAppStoreRequest ? APP_STORE_OUTPUT_SCHEMA : MAPS_OUTPUT_SCHEMA,
+      ),
       402,
     );
   }
 
-  const verification = await verifyPayment(payment, walletAddress, MAPS_PRICE_USDC);
+  const expectedPrice = isAppStoreRequest ? APP_STORE_PRICE_USDC : MAPS_PRICE_USDC;
+  const verification = await verifyPayment(payment, walletAddress, expectedPrice);
   if (!verification.valid) {
     return c.json({
       error: 'Payment verification failed',
@@ -116,6 +158,74 @@ serviceRouter.get('/run', async (c) => {
   if (!checkProxyRateLimit(clientIp)) {
     c.header('Retry-After', '60');
     return c.json({ error: 'Proxy rate limit exceeded. Max 20 requests/min to protect proxy quota.', retryAfter: 60 }, 429);
+  }
+
+  if (isAppStoreRequest) {
+    const store = (c.req.query('store') || '').toLowerCase();
+    if (store !== 'apple' && store !== 'google') {
+      return c.json({ error: 'Missing or invalid store. Use store=apple or store=google.' }, 400);
+    }
+
+    const country = (c.req.query('country') || 'US').toUpperCase();
+    if (!SUPPORTED_APP_COUNTRIES.includes(country as any)) {
+      return c.json({
+        error: `Unsupported country: ${country}. Supported countries: ${SUPPORTED_APP_COUNTRIES.join(', ')}`,
+      }, 400);
+    }
+
+    const limitRaw = c.req.query('limit');
+    let limit = 20;
+    if (limitRaw) {
+      const parsed = parseInt(limitRaw, 10);
+      if (!Number.isFinite(parsed) || parsed < 1 || parsed > 50) {
+        return c.json({ error: 'Invalid limit. Use an integer between 1 and 50.' }, 400);
+      }
+      limit = parsed;
+    }
+
+    const category = c.req.query('category') || 'games';
+    const appId = c.req.query('appId') || undefined;
+    const query = c.req.query('query') || undefined;
+
+    if (requestedType === 'app' && !appId) {
+      return c.json({ error: 'Missing required parameter: appId for type=app' }, 400);
+    }
+
+    if (requestedType === 'search' && !query) {
+      return c.json({ error: 'Missing required parameter: query for type=search' }, 400);
+    }
+
+    try {
+      const proxy = getProxy();
+      const result = await getAppStoreData({
+        type: requestedType as 'rankings' | 'app' | 'search' | 'trending',
+        store,
+        country,
+        category,
+        appId,
+        query,
+        limit,
+      });
+
+      c.header('X-Payment-Settled', 'true');
+      c.header('X-Payment-TxHash', payment.txHash);
+
+      return c.json({
+        ...result,
+        proxy: { country: proxy.country, type: 'mobile' },
+        payment: {
+          txHash: payment.txHash,
+          network: payment.network,
+          amount: verification.amount,
+          settled: true,
+        },
+      });
+    } catch (err: any) {
+      return c.json({
+        error: 'App store intelligence execution failed',
+        message: err?.message || String(err),
+      }, 502);
+    }
   }
 
   const query = c.req.query('query');

--- a/tests/app-store-endpoints.test.ts
+++ b/tests/app-store-endpoints.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x1111111111111111111111111111111111111111';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_02 = '0x0000000000000000000000000000000000000000000000000000000000004e20';
+
+let txCounter = 200;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function installAppStoreFetchMock(recipientAddress: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      const payload = init?.body ? JSON.parse(String(init.body)) : {};
+      if (payload?.method !== 'eth_getTransactionReceipt') {
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(recipientAddress),
+            ],
+            data: USDC_AMOUNT_0_02,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://itunes.apple.com/us/rss/topfreeapplications')) {
+      return new Response(JSON.stringify({
+        feed: {
+          entry: [
+            {
+              id: { attributes: { 'im:id': '324684580' } },
+              'im:name': { label: 'Spotify: Music and Podcasts' },
+              'im:artist': { label: 'Spotify AB' },
+              category: { attributes: { label: 'Music' } },
+              'im:price': { attributes: { amount: '0.00' } },
+              'im:image': [{ label: 'https://cdn/icon-53.png' }, { label: 'https://cdn/icon-75.png' }, { label: 'https://cdn/icon-100.png' }],
+            },
+          ],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://itunes.apple.com/lookup?id=324684580')) {
+      return new Response(JSON.stringify({
+        resultCount: 1,
+        results: [
+          {
+            trackId: 324684580,
+            bundleId: 'com.spotify.music',
+            averageUserRating: 4.8,
+            userRatingCount: 128000,
+            price: 0,
+            features: ['iosUniversal', 'gameCenter', 'in-app-purchases'],
+            currentVersionReleaseDate: '2026-02-20T10:00:00Z',
+            fileSizeBytes: '205520896',
+            artworkUrl512: 'https://cdn/spotify-512.png',
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://play.google.com/store/apps/details?id=com.spotify.music')) {
+      return new Response(`
+        <html>
+          <h1><span>Spotify: Music and Podcasts</span></h1>
+          <a href="/store/apps/dev?id=spotify">Spotify AB</a>
+          <meta itemprop="ratingValue" content="4.4" />
+          <meta itemprop="ratingCount" content="31500000" />
+          <meta itemprop="image" content="https://play-lh.googleusercontent.com/spotify-icon" />
+          <a href="/store/apps/category/MUSIC_AND_AUDIO">Music & Audio</a>
+          <div>In-app purchases</div>
+        </html>
+      `, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in app-store test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('App Store intelligence /api/run', () => {
+  test('returns x402 payload when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/run?type=rankings&store=apple&country=US&category=games'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/run');
+    expect(body.price.amount).toBe('0.02');
+    expect(body.message).toBe('Payment required');
+  });
+
+  test('returns rankings for Apple with valid payment', async () => {
+    const calls = installAppStoreFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/run?type=rankings&store=apple&country=US&category=games&limit=1', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls.some((url) => url.includes('mainnet.base.org'))).toBe(true);
+    expect(calls.some((url) => url.includes('/rss/topfreeapplications/'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.type).toBe('rankings');
+    expect(body.store).toBe('apple');
+    expect(body.country).toBe('US');
+    expect(Array.isArray(body.rankings)).toBe(true);
+    expect(body.rankings[0].appName).toContain('Spotify');
+    expect(body.rankings[0].appId).toBe('com.spotify.music');
+    expect(body.proxy.type).toBe('mobile');
+    expect(body.payment.txHash).toBe(txHash);
+    expect(body.payment.settled).toBe(true);
+  });
+
+  test('returns Google app details with valid payment', async () => {
+    const calls = installAppStoreFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/run?type=app&store=google&country=DE&appId=com.spotify.music', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls.some((url) => url.startsWith('https://play.google.com/store/apps/details?id=com.spotify.music'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.type).toBe('app');
+    expect(body.store).toBe('google');
+    expect(body.app.appName).toContain('Spotify');
+    expect(body.app.appId).toBe('com.spotify.music');
+    expect(body.app.rating).toBe(4.4);
+    expect(body.payment.txHash).toBe(txHash);
+    expect(body.payment.network).toBe('base');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **App Store Intelligence API** requested in #54 by extending `GET /api/run` to support:

- `type=rankings`
- `type=app`
- `type=search`
- `type=trending`

for both `store=apple|google` with required country support (`US, DE, FR, ES, GB, PL`) and x402 payment gating.

## What changed

### 1) New scraper module
- Added `src/scrapers/app-store-scraper.ts`
- Apple App Store support:
  - rankings via iTunes RSS top free apps feed
  - app lookup via iTunes Lookup API
  - search via iTunes Search API
  - reviews via iTunes customer reviews feed
- Google Play support:
  - rankings/trending via collection pages + card extraction
  - app details via app page extraction
  - search via search page extraction

### 2) `/api/run` router upgrade
- Updated `src/service.ts`
- Added request type routing:
  - default `maps`
  - app intelligence modes `rankings|app|search|trending`
- Added app intelligence schema and pricing:
  - `APP_STORE_PRICE_USDC = 0.02`
- Added validation for:
  - `store` (`apple|google`)
  - `country` (US/DE/FR/ES/GB/PL)
  - `limit` (1-50)
  - required params (`appId` for `type=app`, `query` for `type=search`)

### 3) Tests
- Added `tests/app-store-endpoints.test.ts`
- Coverage includes:
  - 402 flow for missing payment
  - paid Apple rankings response
  - paid Google app detail response

## Verification

```bash
bun run typecheck
bun test
```

Both pass locally.

Fixes #54
