### PR TITLE
feat: trend intelligence MVP validation + x402 endpoint tests

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+maxConcurrency = 1

--- a/src/routes/research.ts
+++ b/src/routes/research.ts
@@ -30,7 +30,9 @@ import type {
 
 // Constants
 
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS ?? '';
+function getWalletAddress(): string {
+  return process.env.WALLET_ADDRESS ?? '';
+}
 
 const PRICE_SINGLE = 0.10;
 const PRICE_MULTI = 0.50;
@@ -123,11 +125,21 @@ function checkRateLimit(ip: string): { allowed: boolean; retryAfter: number } {
   return { allowed: true, retryAfter: 0 };
 }
 
-function parseCountry(input: unknown): string {
-  if (typeof input !== 'string') return 'US';
+function parseCountry(input: unknown): { country: string; error?: string } {
+  if (input === undefined || input === null || input === '') {
+    return { country: 'US' };
+  }
+
+  if (typeof input !== 'string') {
+    return { country: '', error: 'country must be a 2-letter ISO code (e.g. US)' };
+  }
+
   const normalized = input.trim().toUpperCase();
-  if (!/^[A-Z]{2}$/.test(normalized)) return 'US';
-  return normalized;
+  if (!/^[A-Z]{2}$/.test(normalized)) {
+    return { country: '', error: 'country must be a 2-letter ISO code (e.g. US)' };
+  }
+
+  return { country: normalized };
 }
 
 function sanitizeTopic(input: unknown): string | null {
@@ -155,13 +167,20 @@ function parsePlatforms(input: unknown): { platforms: Platform[]; error?: string
     return { platforms: [], error: `Too many platforms requested. Max ${SUPPORTED_PLATFORMS.length}` };
   }
 
-  const normalized = input
-    .map((p) => {
-      if (typeof p !== 'string') return '';
-      const key = p.trim().toLowerCase();
-      return PLATFORM_ALIASES[key] ?? key;
-    })
-    .filter((p): p is Platform => SUPPORTED_PLATFORMS.includes(p as Platform));
+  const normalized: Platform[] = [];
+  for (const p of input) {
+    if (typeof p !== 'string') {
+      return { platforms: [], error: 'platforms entries must be strings' };
+    }
+
+    const key = p.trim().toLowerCase();
+    const mapped = (PLATFORM_ALIASES[key] ?? key) as Platform;
+    if (!SUPPORTED_PLATFORMS.includes(mapped)) {
+      return { platforms: [], error: `Unsupported platform: ${p}` };
+    }
+
+    normalized.push(mapped);
+  }
 
   const unique = Array.from(new Set(normalized));
 
@@ -200,7 +219,8 @@ async function getProxyExitIp(): Promise<string | null> {
 export const researchRouter = new Hono();
 
 researchRouter.post('/', async (c) => {
-  if (!WALLET_ADDRESS) {
+  const walletAddress = getWalletAddress();
+  if (!walletAddress) {
     return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
   }
 
@@ -233,7 +253,7 @@ researchRouter.post('/', async (c) => {
   const payment = extractPayment(c);
   if (!payment) {
     return c.json(
-      build402Response('/api/research', DESCRIPTION, PRICE_MULTI, WALLET_ADDRESS, OUTPUT_SCHEMA),
+      build402Response('/api/research', DESCRIPTION, PRICE_MULTI, walletAddress, OUTPUT_SCHEMA),
       402,
     );
   }
@@ -269,16 +289,23 @@ researchRouter.post('/', async (c) => {
   if (!Number.isFinite(rawDays)) {
     return c.json({ error: 'days must be a valid number' }, 400);
   }
-  const days = Math.min(Math.max(Math.floor(rawDays), 1), MAX_DAYS);
+  const days = Math.floor(rawDays);
+  if (days < 1 || days > MAX_DAYS) {
+    return c.json({ error: `days must be between 1 and ${MAX_DAYS}` }, 400);
+  }
 
-  const country = parseCountry(body.country);
+  const countryResult = parseCountry(body.country);
+  if (countryResult.error) {
+    return c.json({ error: countryResult.error }, 400);
+  }
+  const country = countryResult.country;
 
   // 4 platforms = full report, 2-3 = multi, 1 = single
   const price = platforms.length >= 4 ? PRICE_FULL : platforms.length >= 2 ? PRICE_MULTI : PRICE_SINGLE;
 
   let verification: Awaited<ReturnType<typeof verifyPayment>>;
   try {
-    verification = await verifyPayment(payment, WALLET_ADDRESS, price);
+    verification = await verifyPayment(payment, walletAddress, price);
   } catch (error) {
     console.error('[research] Payment verification error:', error);
     return c.json({ error: 'Payment verification temporarily unavailable' }, 502);

--- a/tests/trend-intelligence-endpoints.test.ts
+++ b/tests/trend-intelligence-endpoints.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+process.env.WALLET_ADDRESS = '0x1111111111111111111111111111111111111111';
+process.env.PROXY_HOST = 'proxy.test.local';
+process.env.PROXY_HTTP_PORT = '8080';
+process.env.PROXY_USER = 'tester';
+process.env.PROXY_PASS = 'secret';
+process.env.PROXY_COUNTRY = 'US';
+
+import app from '../src/index';
+
+const TEST_WALLET = process.env.WALLET_ADDRESS!;
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_10 = '0x00000000000000000000000000000000000000000000000000000000000186a0';
+
+let txCounter = 10_000;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function installFetchMock(recipientAddress: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      const payload = init?.body ? JSON.parse(String(init.body)) : {};
+      if (payload?.method !== 'eth_getTransactionReceipt') {
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(recipientAddress),
+            ],
+            data: USDC_AMOUNT_0_10,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://api.ipify.org')) {
+      return new Response(JSON.stringify({ ip: '198.51.100.10' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://www.reddit.com/search.json')) {
+      return new Response(JSON.stringify({
+        data: {
+          children: [
+            {
+              kind: 't3',
+              data: {
+                id: 'abc123',
+                title: 'AI coding assistants are improving rapidly',
+                subreddit: 'programming',
+                score: 250,
+                num_comments: 42,
+                url: 'https://example.com/post',
+                permalink: '/r/programming/comments/abc123/test',
+                created_utc: Math.floor(Date.now() / 1000),
+                selftext: 'Lots of momentum for tool adoption.',
+                author: 'dev_user',
+                upvote_ratio: 0.96,
+                is_video: false,
+                link_flair_text: null,
+              },
+            },
+          ],
+          after: null,
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('Trend intelligence endpoints', () => {
+  test('POST /api/research returns 402 with x402 payload when payment is missing', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/research', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ topic: 'AI coding assistants', platforms: ['reddit'] }),
+      }),
+    );
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/research');
+    expect(body.message).toBe('Payment required');
+    expect(body.outputSchema).toBeDefined();
+  });
+
+  test('POST /api/research returns 200 for a valid paid request', async () => {
+    const calls = installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/research', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+        body: JSON.stringify({
+          topic: 'AI coding assistants',
+          platforms: ['reddit'],
+          days: 30,
+          country: 'US',
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Payment-Settled')).toBe('true');
+    expect(calls.some((url) => url.includes('mainnet.base.org'))).toBe(true);
+    expect(calls.some((url) => url.startsWith('https://www.reddit.com/search.json'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.topic).toBe('AI coding assistants');
+    expect(body.timeframe).toBe('last 30 days');
+    expect(Array.isArray(body.top_discussions)).toBe(true);
+    expect(body.meta?.proxy?.type).toBe('mobile');
+    expect(body.payment?.settled).toBe(true);
+    expect(body.payment?.txHash).toBe(txHash);
+  });
+
+  test('POST /api/research returns 400 for invalid parameters', async () => {
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/research', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+        body: JSON.stringify({
+          topic: 'AI coding assistants',
+          platforms: ['reddit', 'unknown-platform'],
+          days: 120,
+          country: 'USA',
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error).toContain('Unsupported platform');
+  });
+});


### PR DESCRIPTION
## Summary
Implements a focused MVP hardening pass for the Trend Intelligence API (`/api/research`) tied to issue #70.

### What changed
- Strengthened input validation in `src/routes/research.ts`:
  - reject invalid `country` values (must be 2-letter ISO code)
  - reject out-of-range `days` values (`1..90`) instead of silently clamping
  - reject unsupported/non-string entries in `platforms`
- Made wallet resolution runtime-safe in research route (reads `WALLET_ADDRESS` at request time).
- Added endpoint tests in `tests/trend-intelligence-endpoints.test.ts` covering:
  - unpaid `402` response path
  - paid success path (x402 headers + response contract)
  - parameter validation failure
- Added `bunfig.toml` with `test.maxConcurrency = 1` to make fetch-mocking endpoint tests deterministic.

## Verification
- `bun test` ✅
- `bun run typecheck` ✅

Closes #70
