### PR TITLE
feat: add mobile ad verification modes to /api/run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ app.get('/', (c) => c.json({
   description: process.env.SERVICE_DESCRIPTION || 'AI agent intelligence services powered by real 4G/5G mobile proxies.',
   version: '1.0.0',
   endpoints: [
-    { method: 'GET', path: '/api/run', description: 'Google Maps Lead Generator — search businesses by category + location', price: '0.005 USDC' },
+    { method: 'GET', path: '/api/run', description: 'Mode router: Maps lead gen or ad intelligence (`type=search_ads|display_ads|advertiser`)', price: '0.005-0.03 USDC' },
     { method: 'GET', path: '/api/details', description: 'Google Maps Place Details — detailed business info by Place ID', price: '0.005 USDC' },
     { method: 'GET', path: '/api/jobs', description: 'Get job listings (Indeed/LinkedIn) with salary + date + proxy metadata' },
     { method: 'GET', path: '/api/reviews/search', description: 'Search businesses by query + location', price: '0.01 USDC' },

--- a/src/scrapers/ad-intelligence-scraper.ts
+++ b/src/scrapers/ad-intelligence-scraper.ts
@@ -1,0 +1,264 @@
+import { proxyFetch } from '../proxy';
+import { scrapeMobileSERP } from './serp-tracker';
+
+const SUPPORTED_COUNTRIES = new Set(['US', 'DE', 'FR', 'ES', 'GB', 'PL']);
+
+const COUNTRY_TO_LANGUAGE: Record<string, string> = {
+  US: 'en',
+  GB: 'en',
+  DE: 'de',
+  FR: 'fr',
+  ES: 'es',
+  PL: 'pl',
+};
+
+const AD_NETWORK_PATTERNS: Array<{ network: string; pattern: RegExp }> = [
+  { network: 'google', pattern: /(doubleclick|googlesyndication|googleadservices|adservice\.google)/i },
+  { network: 'meta', pattern: /(facebook\.com\/tr|connect\.facebook\.net)/i },
+  { network: 'amazon', pattern: /(amazon-adsystem)/i },
+  { network: 'taboola', pattern: /(taboola)/i },
+  { network: 'outbrain', pattern: /(outbrain)/i },
+  { network: 'xandr', pattern: /(adnxs)/i },
+  { network: 'criteo', pattern: /(criteo)/i },
+];
+
+export interface SearchAdsResult {
+  type: 'search_ads';
+  query: string;
+  country: string;
+  timestamp: string;
+  ads: Array<{
+    position: number;
+    placement: 'top' | 'bottom';
+    title: string;
+    description: string;
+    displayUrl: string;
+    finalUrl: string;
+    advertiser: string;
+    extensions: string[];
+    isResponsive: boolean;
+  }>;
+  organic_count: number;
+  total_ads: number;
+  ad_positions: {
+    top: number;
+    bottom: number;
+  };
+}
+
+export interface DisplayAdsResult {
+  type: 'display_ads';
+  url: string;
+  country: string;
+  timestamp: string;
+  ads: Array<{
+    slot: number;
+    network: string;
+    creativeType: 'iframe' | 'script' | 'image';
+    sourceUrl: string;
+  }>;
+  total_ads: number;
+  network_breakdown: Record<string, number>;
+}
+
+export interface AdvertiserLookupResult {
+  type: 'advertiser';
+  domain: string;
+  country: string;
+  timestamp: string;
+  transparency_url: string;
+  ads_found: Array<{
+    advertiser: string;
+    headline: string;
+    targetUrl: string;
+  }>;
+  total_ads: number;
+}
+
+function toAbsoluteUrl(candidate: string, base: string): string {
+  try {
+    return new URL(candidate, base).toString();
+  } catch {
+    return candidate;
+  }
+}
+
+function classifyNetwork(url: string): string {
+  for (const entry of AD_NETWORK_PATTERNS) {
+    if (entry.pattern.test(url)) return entry.network;
+  }
+
+  try {
+    const host = new URL(url).hostname;
+    return host.replace(/^www\./, '').split('.').slice(-2).join('.');
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function normalizeCountry(country: string | undefined): string {
+  const normalized = (country || 'US').trim().toUpperCase();
+  if (!SUPPORTED_COUNTRIES.has(normalized)) {
+    throw new Error('Unsupported country. Use one of: US, DE, FR, ES, GB, PL');
+  }
+  return normalized;
+}
+
+export function normalizeDomain(domain: string | undefined): string {
+  if (!domain) throw new Error('Missing required parameter: domain');
+  const cleaned = domain.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/$/, '');
+  if (!/^[a-z0-9.-]+\.[a-z]{2,}$/.test(cleaned)) {
+    throw new Error('Invalid domain format. Example: nordvpn.com');
+  }
+  return cleaned;
+}
+
+function extractAdvertiser(displayUrl: string, finalUrl: string): string {
+  const seed = finalUrl || displayUrl;
+  try {
+    const host = new URL(seed.startsWith('http') ? seed : `https://${seed}`).hostname;
+    return host.replace(/^www\./, '').split('.')[0] || 'unknown';
+  } catch {
+    return (displayUrl || 'unknown').replace(/^www\./, '').split('.')[0] || 'unknown';
+  }
+}
+
+export async function fetchSearchAds(query: string, country: string): Promise<SearchAdsResult> {
+  const normalizedCountry = normalizeCountry(country);
+  const language = COUNTRY_TO_LANGUAGE[normalizedCountry] || 'en';
+  const serp = await scrapeMobileSERP(query, normalizedCountry.toLowerCase(), language);
+
+  const ads = serp.ads.map((ad) => ({
+    position: ad.position,
+    placement: ad.isTop ? 'top' as const : 'bottom' as const,
+    title: ad.title,
+    description: ad.description,
+    displayUrl: ad.displayUrl,
+    finalUrl: ad.url,
+    advertiser: extractAdvertiser(ad.displayUrl, ad.url),
+    extensions: [],
+    isResponsive: true,
+  }));
+
+  return {
+    type: 'search_ads',
+    query,
+    country: normalizedCountry,
+    timestamp: new Date().toISOString(),
+    ads,
+    organic_count: serp.organic.length,
+    total_ads: ads.length,
+    ad_positions: {
+      top: ads.filter((ad) => ad.placement === 'top').length,
+      bottom: ads.filter((ad) => ad.placement === 'bottom').length,
+    },
+  };
+}
+
+export async function fetchDisplayAds(targetUrl: string, country: string): Promise<DisplayAdsResult> {
+  const normalizedCountry = normalizeCountry(country);
+
+  const response = await proxyFetch(targetUrl, {
+    timeoutMs: 45_000,
+    maxRetries: 2,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch target URL (${response.status})`);
+  }
+
+  const html = await response.text();
+  const adMap = new Map<string, { creativeType: 'iframe' | 'script' | 'image'; sourceUrl: string }>();
+
+  const iframeMatches = html.matchAll(/<iframe[^>]+src=["']([^"']+)["'][^>]*>/gi);
+  for (const match of iframeMatches) {
+    const sourceUrl = toAbsoluteUrl(match[1], targetUrl);
+    if (AD_NETWORK_PATTERNS.some((entry) => entry.pattern.test(sourceUrl))) {
+      adMap.set(`iframe:${sourceUrl}`, { creativeType: 'iframe', sourceUrl });
+    }
+  }
+
+  const scriptMatches = html.matchAll(/<script[^>]+src=["']([^"']+)["'][^>]*>/gi);
+  for (const match of scriptMatches) {
+    const sourceUrl = toAbsoluteUrl(match[1], targetUrl);
+    if (AD_NETWORK_PATTERNS.some((entry) => entry.pattern.test(sourceUrl))) {
+      adMap.set(`script:${sourceUrl}`, { creativeType: 'script', sourceUrl });
+    }
+  }
+
+  const imageMatches = html.matchAll(/<img[^>]+src=["']([^"']+)["'][^>]*>/gi);
+  for (const match of imageMatches) {
+    const sourceUrl = toAbsoluteUrl(match[1], targetUrl);
+    if (AD_NETWORK_PATTERNS.some((entry) => entry.pattern.test(sourceUrl))) {
+      adMap.set(`image:${sourceUrl}`, { creativeType: 'image', sourceUrl });
+    }
+  }
+
+  const ads = Array.from(adMap.values()).map((entry, index) => ({
+    slot: index + 1,
+    network: classifyNetwork(entry.sourceUrl),
+    creativeType: entry.creativeType,
+    sourceUrl: entry.sourceUrl,
+  }));
+
+  const network_breakdown: Record<string, number> = {};
+  for (const ad of ads) {
+    network_breakdown[ad.network] = (network_breakdown[ad.network] || 0) + 1;
+  }
+
+  return {
+    type: 'display_ads',
+    url: targetUrl,
+    country: normalizedCountry,
+    timestamp: new Date().toISOString(),
+    ads,
+    total_ads: ads.length,
+    network_breakdown,
+  };
+}
+
+export async function fetchAdvertiserAds(domain: string, country: string): Promise<AdvertiserLookupResult> {
+  const normalizedCountry = normalizeCountry(country);
+  const normalizedDomain = normalizeDomain(domain);
+
+  const transparencyUrl = `https://adstransparency.google.com/?region=${normalizedCountry}&domain=${encodeURIComponent(normalizedDomain)}`;
+  const response = await proxyFetch(transparencyUrl, {
+    timeoutMs: 45_000,
+    maxRetries: 2,
+    headers: {
+      Accept: 'text/html,application/xhtml+xml',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch advertiser data (${response.status})`);
+  }
+
+  const html = await response.text();
+  const adsFound: Array<{ advertiser: string; headline: string; targetUrl: string }> = [];
+  const seen = new Set<string>();
+
+  const jsonLikePattern = /"headline"\s*:\s*"([^"]{2,140})"[\s\S]{0,220}?"(?:targetUrl|landingPage)"\s*:\s*"(https?:\\\/\\\/[^\"]+)"/gi;
+  for (const match of html.matchAll(jsonLikePattern)) {
+    const headline = match[1].replace(/\\u0026/g, '&').trim();
+    const targetUrl = match[2].replace(/\\\//g, '/').trim();
+    const key = `${headline}|${targetUrl}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    adsFound.push({
+      advertiser: normalizedDomain,
+      headline,
+      targetUrl,
+    });
+  }
+
+  return {
+    type: 'advertiser',
+    domain: normalizedDomain,
+    country: normalizedCountry,
+    timestamp: new Date().toISOString(),
+    transparency_url: transparencyUrl,
+    ads_found: adsFound,
+    total_ads: adsFound.length,
+  };
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,6 +29,7 @@ import {
 } from './scrapers/linkedin-enrichment';
 import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile } from './scrapers/instagram-scraper';
 import { searchReddit, getSubreddit, getTrending, getComments } from './scrapers/reddit-scraper';
+import { fetchAdvertiserAds, fetchDisplayAds, fetchSearchAds, normalizeCountry } from './scrapers/ad-intelligence-scraper';
 
 export const serviceRouter = new Hono();
 
@@ -41,6 +42,8 @@ const PRICE_USDC = 0.005;
 const DESCRIPTION = 'Job Market Intelligence API (Indeed/LinkedIn): title, company, location, salary, date, link, remote + proxy exit metadata.';
 const MAPS_PRICE_USDC = 0.005;
 const MAPS_DESCRIPTION = 'Extract structured business data from Google Maps: name, address, phone, website, email, hours, ratings, reviews, categories, and geocoordinates. Search by category + location with full pagination.';
+const AD_INTEL_PRICE_USDC = 0.03;
+const AD_INTEL_DESCRIPTION = 'Mobile Ad Verification & Creative Intelligence: search ads, display ad capture, and advertiser lookup from real mobile proxy traffic.';
 
 const MAPS_OUTPUT_SCHEMA = {
   input: {
@@ -74,6 +77,23 @@ const MAPS_OUTPUT_SCHEMA = {
   },
 };
 
+const AD_OUTPUT_SCHEMA = {
+  input: {
+    type: 'search_ads | display_ads | advertiser (required for ad intelligence mode)',
+    query: 'string (required for search_ads)',
+    url: 'string (required for display_ads)',
+    domain: 'string (required for advertiser)',
+    country: 'US | DE | FR | ES | GB | PL (optional, default: US)',
+  },
+  output: {
+    type: 'search_ads | display_ads | advertiser',
+    ads: 'Ad records for requested mode',
+    total_ads: 'number',
+    proxy: '{ country: string, type: "mobile" }',
+    payment: '{ txHash, network, amount, settled }',
+  },
+};
+
 async function getProxyExitIp(): Promise<string | null> {
   try {
     const r = await proxyFetch('https://api.ipify.org?format=json', {
@@ -95,15 +115,21 @@ serviceRouter.get('/run', async (c) => {
     return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
   }
 
+  const mode = (c.req.query('type') || 'maps').trim().toLowerCase();
+  const isAdMode = mode === 'search_ads' || mode === 'display_ads' || mode === 'advertiser';
+  const price = isAdMode ? AD_INTEL_PRICE_USDC : MAPS_PRICE_USDC;
+  const description = isAdMode ? AD_INTEL_DESCRIPTION : MAPS_DESCRIPTION;
+  const outputSchema = isAdMode ? AD_OUTPUT_SCHEMA : MAPS_OUTPUT_SCHEMA;
+
   const payment = extractPayment(c);
   if (!payment) {
     return c.json(
-      build402Response('/api/run', MAPS_DESCRIPTION, MAPS_PRICE_USDC, walletAddress, MAPS_OUTPUT_SCHEMA),
+      build402Response('/api/run', description, price, walletAddress, outputSchema),
       402,
     );
   }
 
-  const verification = await verifyPayment(payment, walletAddress, MAPS_PRICE_USDC);
+  const verification = await verifyPayment(payment, walletAddress, price);
   if (!verification.valid) {
     return c.json({
       error: 'Payment verification failed',
@@ -118,40 +144,88 @@ serviceRouter.get('/run', async (c) => {
     return c.json({ error: 'Proxy rate limit exceeded. Max 20 requests/min to protect proxy quota.', retryAfter: 60 }, 429);
   }
 
-  const query = c.req.query('query');
-  const location = c.req.query('location');
-  const limitParam = c.req.query('limit');
-  const pageToken = c.req.query('pageToken');
-
-  if (!query) {
-    return c.json({
-      error: 'Missing required parameter: query',
-      hint: 'Provide a search query like ?query=plumbers&location=Austin+TX',
-      example: '/api/run?query=restaurants&location=New+York+City&limit=20',
-    }, 400);
-  }
-
-  if (!location) {
-    return c.json({
-      error: 'Missing required parameter: location',
-      hint: 'Provide a location like ?query=plumbers&location=Austin+TX',
-      example: '/api/run?query=restaurants&location=New+York+City&limit=20',
-    }, 400);
-  }
-
-  let limit = 20;
-  if (limitParam) {
-    const parsed = parseInt(limitParam);
-    if (isNaN(parsed) || parsed < 1) {
-      return c.json({ error: 'Invalid limit parameter: must be a positive integer' }, 400);
-    }
-    limit = Math.min(parsed, 100);
-  }
-
-  const startIndex = pageToken ? parseInt(pageToken) || 0 : 0;
-
   try {
     const proxy = getProxy();
+
+    if (isAdMode) {
+      const country = normalizeCountry(c.req.query('country'));
+      let result: any;
+
+      if (mode === 'search_ads') {
+        const query = c.req.query('query');
+        if (!query) {
+          return c.json({
+            error: 'Missing required parameter: query',
+            example: '/api/run?type=search_ads&query=best+vpn&country=US',
+          }, 400);
+        }
+        result = await fetchSearchAds(query, country);
+      } else if (mode === 'display_ads') {
+        const url = c.req.query('url');
+        if (!url) {
+          return c.json({
+            error: 'Missing required parameter: url',
+            example: '/api/run?type=display_ads&url=https://techcrunch.com&country=DE',
+          }, 400);
+        }
+        result = await fetchDisplayAds(url, country);
+      } else {
+        const domain = c.req.query('domain');
+        if (!domain) {
+          return c.json({
+            error: 'Missing required parameter: domain',
+            example: '/api/run?type=advertiser&domain=nordvpn.com&country=US',
+          }, 400);
+        }
+        result = await fetchAdvertiserAds(domain, country);
+      }
+
+      c.header('X-Payment-Settled', 'true');
+      c.header('X-Payment-TxHash', payment.txHash);
+
+      return c.json({
+        ...result,
+        proxy: { country: proxy.country, type: 'mobile' },
+        payment: {
+          txHash: payment.txHash,
+          network: payment.network,
+          amount: verification.amount,
+          settled: true,
+        },
+      });
+    }
+
+    const query = c.req.query('query');
+    const location = c.req.query('location');
+    const limitParam = c.req.query('limit');
+    const pageToken = c.req.query('pageToken');
+
+    if (!query) {
+      return c.json({
+        error: 'Missing required parameter: query',
+        hint: 'Provide a search query like ?query=plumbers&location=Austin+TX',
+        example: '/api/run?query=restaurants&location=New+York+City&limit=20',
+      }, 400);
+    }
+
+    if (!location) {
+      return c.json({
+        error: 'Missing required parameter: location',
+        hint: 'Provide a location like ?query=plumbers&location=Austin+TX',
+        example: '/api/run?query=restaurants&location=New+York+City&limit=20',
+      }, 400);
+    }
+
+    let limit = 20;
+    if (limitParam) {
+      const parsed = parseInt(limitParam);
+      if (isNaN(parsed) || parsed < 1) {
+        return c.json({ error: 'Invalid limit parameter: must be a positive integer' }, 400);
+      }
+      limit = Math.min(parsed, 100);
+    }
+
+    const startIndex = pageToken ? parseInt(pageToken) || 0 : 0;
     const result = await scrapeGoogleMaps(query, location, limit, startIndex);
 
     c.header('X-Payment-Settled', 'true');
@@ -168,10 +242,14 @@ serviceRouter.get('/run', async (c) => {
       },
     });
   } catch (err: any) {
+    if (typeof err?.message === 'string' && err.message.includes('Unsupported country')) {
+      return c.json({ error: err.message }, 400);
+    }
+
     return c.json({
       error: 'Service execution failed',
       message: err.message,
-      hint: 'Google Maps may be temporarily blocking requests. Try again in a few minutes.',
+      hint: 'Request failed via proxy upstream. Try again in a few minutes.',
     }, 502);
   }
 });

--- a/tests/ad-intelligence-endpoints.test.ts
+++ b/tests/ad-intelligence-endpoints.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x1111111111111111111111111111111111111111';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_03 = '0x0000000000000000000000000000000000000000000000000000000000007530';
+
+const SEARCH_HTML = `
+<html>
+  <body>
+    <div id="tads">
+      Sponsored
+      <a href="https://nordvpn.com/deal">NordVPN - #1 VPN Service</a>
+      <div>Military-grade encryption. 5,000+ servers.</div>
+    </div>
+    <div class="g">
+      <a href="https://www.wired.com/story/best-vpn/">Best VPNs</a>
+      <span class="st">Independent editorial review.</span>
+    </div>
+  </body>
+</html>
+`;
+
+const DISPLAY_HTML = `
+<html>
+  <body>
+    <iframe src="https://googleads.g.doubleclick.net/pagead/id"></iframe>
+    <script src="https://cdn.taboola.com/libtrc/universal.js"></script>
+    <img src="https://www.googleadservices.com/pagead/aclk?x=1" />
+  </body>
+</html>
+`;
+
+const ADVERTISER_HTML = `
+<html><body>
+<script>
+{"headline":"Summer VPN Sale","targetUrl":"https:\\/\\/nordvpn.com\\/offer"}
+</script>
+</body></html>
+`;
+
+let txCounter = 100;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function installFetchMock(): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      const payload = init?.body ? JSON.parse(String(init.body)) : {};
+      if (payload?.method !== 'eth_getTransactionReceipt') {
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(TEST_WALLET),
+            ],
+            data: USDC_AMOUNT_0_03,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://www.google.com/search?')) {
+      return new Response(SEARCH_HTML, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    if (url.startsWith('https://techcrunch.com')) {
+      return new Response(DISPLAY_HTML, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    if (url.startsWith('https://adstransparency.google.com/')) {
+      return new Response(ADVERTISER_HTML, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('Ad intelligence via /api/run', () => {
+  test('returns 402 payload for ad mode without payment', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/run?type=search_ads&query=best+vpn&country=US'));
+    expect(res.status).toBe(402);
+
+    const body = await res.json() as any;
+    expect(body.resource).toBe('/api/run');
+    expect(body.price.amount).toBe('0.03');
+    expect(body.outputSchema?.input?.type).toContain('search_ads');
+  });
+
+  test('returns search ads payload for paid request', async () => {
+    const calls = installFetchMock();
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/run?type=search_ads&query=best+vpn&country=US', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+
+    expect(body.type).toBe('search_ads');
+    expect(body.query).toBe('best vpn');
+    expect(body.country).toBe('US');
+    expect(body.total_ads).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(body.ads)).toBe(true);
+    expect(body.payment.txHash).toBe(txHash);
+    expect(calls.some((url) => url.includes('mainnet.base.org'))).toBe(true);
+    expect(calls.some((url) => url.startsWith('https://www.google.com/search?'))).toBe(true);
+  });
+
+  test('supports display_ads and advertiser modes', async () => {
+    installFetchMock();
+
+    const txDisplay = nextBaseTxHash();
+    const displayRes = await app.fetch(new Request('http://localhost/api/run?type=display_ads&url=https://techcrunch.com&country=DE', {
+      headers: {
+        'X-Payment-Signature': txDisplay,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(displayRes.status).toBe(200);
+    const displayBody = await displayRes.json() as any;
+    expect(displayBody.type).toBe('display_ads');
+    expect(displayBody.country).toBe('DE');
+    expect(displayBody.total_ads).toBeGreaterThanOrEqual(1);
+
+    const txAdvertiser = nextBaseTxHash();
+    const advertiserRes = await app.fetch(new Request('http://localhost/api/run?type=advertiser&domain=nordvpn.com&country=US', {
+      headers: {
+        'X-Payment-Signature': txAdvertiser,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(advertiserRes.status).toBe(200);
+    const advertiserBody = await advertiserRes.json() as any;
+    expect(advertiserBody.type).toBe('advertiser');
+    expect(advertiserBody.domain).toBe('nordvpn.com');
+    expect(Array.isArray(advertiserBody.ads_found)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Implements Mobile Ad Verification & Creative Intelligence on the existing `/api/run` router by adding three paid modes:

- `type=search_ads` → Google search ad capture from mobile SERP
- `type=display_ads` → display ad network extraction for a target page
- `type=advertiser` → advertiser lookup via Google Ads Transparency surface

## What changed
- Added `src/scrapers/ad-intelligence-scraper.ts`
  - country validation (`US/DE/FR/ES/GB/PL`)
  - `fetchSearchAds(query, country)` using existing mobile SERP scraper
  - `fetchDisplayAds(url, country)` with iframe/script/img ad network extraction
  - `fetchAdvertiserAds(domain, country)` with transparency lookup parsing
- Updated `src/service.ts`
  - `/api/run` now supports `search_ads | display_ads | advertiser` while preserving default maps behavior
  - per-mode x402 pricing/schema (`$0.03` for ad intelligence)
  - validation + normalized error responses
- Added tests `tests/ad-intelligence-endpoints.test.ts`
  - 402 contract for ad mode
  - paid success path for `search_ads`
  - paid success paths for `display_ads` and `advertiser`
- Updated endpoint description in `src/index.ts`

## Validation
- `bun test tests/maps-endpoints.test.ts tests/ad-intelligence-endpoints.test.ts`
- `bun run typecheck`

Closes #53
