### PR TITLE
feat: add X/Twitter real-time search API endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,11 @@ app.get('/health', (c) => c.json({
     '/api/jobs',
     '/api/research',
     '/api/trending',
+    '/api/x/search',
+    '/api/x/trending',
+    '/api/x/user/:handle',
+    '/api/x/user/:handle/tweets',
+    '/api/x/thread/:tweet_id',
     '/api/reviews/search',
     '/api/reviews/:place_id',
     '/api/reviews/summary/:place_id',
@@ -91,6 +96,11 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/run', description: 'Google Maps Lead Generator — search businesses by category + location', price: '0.005 USDC' },
     { method: 'GET', path: '/api/details', description: 'Google Maps Place Details — detailed business info by Place ID', price: '0.005 USDC' },
     { method: 'GET', path: '/api/jobs', description: 'Get job listings (Indeed/LinkedIn) with salary + date + proxy metadata' },
+    { method: 'GET', path: '/api/x/search', description: 'Search X/Twitter posts by keyword/hashtag', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/x/trending', description: 'Trending X/Twitter topics by country', price: '0.005 USDC' },
+    { method: 'GET', path: '/api/x/user/:handle', description: 'X/Twitter user profile by handle', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/x/user/:handle/tweets', description: 'Recent tweets for a handle', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/x/thread/:tweet_id', description: 'Extract tweet thread context by tweet ID', price: '0.02 USDC' },
     { method: 'GET', path: '/api/reviews/search', description: 'Search businesses by query + location', price: '0.01 USDC' },
     { method: 'GET', path: '/api/reviews/:place_id', description: 'Fetch Google reviews by Place ID', price: '0.02 USDC' },
     { method: 'GET', path: '/api/business/:place_id', description: 'Get business details + review summary', price: '0.01 USDC' },
@@ -128,7 +138,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/jobs', '/api/x/search', '/api/x/trending', '/api/x/user/:handle', '/api/x/user/:handle/tweets', '/api/x/thread/:tweet_id', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/routes/x.ts
+++ b/src/routes/x.ts
@@ -1,0 +1,292 @@
+import { Hono, type Context } from 'hono';
+import { build402Response, extractPayment, verifyPayment } from '../payment';
+import { getProxy, proxyFetch } from '../proxy';
+import { getXThread, getXTrending, getXUser, getXUserTweets, searchX, type XSortMode } from '../scrapers/x-scraper';
+
+export const xRouter = new Hono();
+
+const PRICE_SEARCH = 0.01;
+const PRICE_TRENDING = 0.005;
+const PRICE_USER = 0.01;
+const PRICE_THREAD = 0.02;
+
+function getWalletAddress(): string {
+  return process.env.WALLET_ADDRESS ?? "";
+}
+
+function parseLimit(raw: string | undefined, fallback: number, max: number): number {
+  const parsed = Number.parseInt(raw ?? String(fallback), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(parsed, 1), max);
+}
+
+function parseCountry(raw: string | undefined): string {
+  if (!raw) return 'US';
+  const country = raw.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(country)) return 'US';
+  return country;
+}
+
+function parseSort(raw: string | undefined): XSortMode {
+  return raw?.toLowerCase() === 'top' ? 'top' : 'latest';
+}
+
+async function getProxyExitIp(): Promise<string | null> {
+  try {
+    const r = await proxyFetch('https://api.ipify.org?format=json', {
+      headers: { Accept: 'application/json' },
+      timeoutMs: 8_000,
+      maxRetries: 1,
+    });
+
+    if (!r.ok) return null;
+    const payload = await r.json() as { ip?: unknown };
+    return typeof payload.ip === 'string' ? payload.ip : null;
+  } catch {
+    return null;
+  }
+}
+
+async function verifyPaidRequest(c: Context, price: number, resource: string, description: string, outputSchema: Record<string, unknown>) {
+  const walletAddress = getWalletAddress();
+  if (!walletAddress) {
+    return { response: c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500) };
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return { response: c.json(build402Response(resource, description, price, walletAddress, outputSchema), 402) };
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, price);
+  if (!verification.valid) {
+    return { response: c.json({ error: 'Payment verification failed', reason: verification.error }, 402) };
+  }
+
+  return {
+    payment,
+    verification,
+    response: null,
+  };
+}
+
+xRouter.get('/search', async (c) => {
+  const verified = await verifyPaidRequest(
+    c,
+    PRICE_SEARCH,
+    '/api/x/search',
+    'Search X/Twitter by keyword or hashtag via mobile proxy intelligence.',
+    {
+      input: {
+        query: 'string (required)',
+        sort: '"latest" | "top" (default: latest)',
+        limit: 'number (default: 20, max: 50)',
+      },
+      output: {
+        query: 'string',
+        sort: 'string',
+        results: 'XSearchResult[]',
+      },
+    },
+  );
+  if (verified.response) return verified.response;
+
+  const query = c.req.query('query');
+  if (!query) {
+    return c.json({ error: 'Missing required parameter: query', example: '/api/x/search?query=openclaw&sort=latest&limit=20' }, 400);
+  }
+
+  const sort = parseSort(c.req.query('sort'));
+  const limit = parseLimit(c.req.query('limit'), 20, 50);
+
+  const proxy = getProxy();
+  const ip = await getProxyExitIp();
+  const results = await searchX(query, sort, limit);
+
+  c.header('X-Payment-Settled', 'true');
+  c.header('X-Payment-TxHash', verified.payment.txHash);
+
+  return c.json({
+    query,
+    sort,
+    results,
+    meta: {
+      total_results: results.length,
+      proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || 'mobile', type: 'mobile' },
+    },
+    payment: {
+      txHash: verified.payment.txHash,
+      network: verified.payment.network,
+      amount: verified.verification.amount,
+      settled: true,
+    },
+  });
+});
+
+xRouter.get('/trending', async (c) => {
+  const verified = await verifyPaidRequest(
+    c,
+    PRICE_TRENDING,
+    '/api/x/trending',
+    'Get trending X/Twitter topics by country.',
+    {
+      input: {
+        country: 'string (optional, default: US)',
+        limit: 'number (default: 20, max: 50)',
+      },
+      output: {
+        country: 'string',
+        trends: 'XSearchResult[]',
+      },
+    },
+  );
+  if (verified.response) return verified.response;
+
+  const country = parseCountry(c.req.query('country'));
+  const limit = parseLimit(c.req.query('limit'), 20, 50);
+
+  const proxy = getProxy();
+  const ip = await getProxyExitIp();
+  const trends = await getXTrending(country, limit);
+
+  c.header('X-Payment-Settled', 'true');
+  c.header('X-Payment-TxHash', verified.payment.txHash);
+
+  return c.json({
+    country,
+    trends,
+    meta: {
+      total_results: trends.length,
+      proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || 'mobile', type: 'mobile' },
+    },
+    payment: {
+      txHash: verified.payment.txHash,
+      network: verified.payment.network,
+      amount: verified.verification.amount,
+      settled: true,
+    },
+  });
+});
+
+xRouter.get('/user/:handle', async (c) => {
+  const verified = await verifyPaidRequest(
+    c,
+    PRICE_USER,
+    '/api/x/user/:handle',
+    'Get X/Twitter user profile by handle.',
+    {
+      input: { handle: 'string (required, in URL path)' },
+      output: { user: 'XUserProfile' },
+    },
+  );
+  if (verified.response) return verified.response;
+
+  const handle = c.req.param('handle');
+  if (!handle) return c.json({ error: 'Missing handle in URL path' }, 400);
+
+  const proxy = getProxy();
+  const ip = await getProxyExitIp();
+  const user = await getXUser(handle);
+
+  if (!user) {
+    return c.json({ error: 'User profile not found or unavailable' }, 404);
+  }
+
+  c.header('X-Payment-Settled', 'true');
+  c.header('X-Payment-TxHash', verified.payment.txHash);
+
+  return c.json({
+    user,
+    meta: { proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || 'mobile', type: 'mobile' } },
+    payment: {
+      txHash: verified.payment.txHash,
+      network: verified.payment.network,
+      amount: verified.verification.amount,
+      settled: true,
+    },
+  });
+});
+
+xRouter.get('/user/:handle/tweets', async (c) => {
+  const verified = await verifyPaidRequest(
+    c,
+    PRICE_USER,
+    '/api/x/user/:handle/tweets',
+    'Get recent tweets by X handle.',
+    {
+      input: {
+        handle: 'string (required, in URL path)',
+        limit: 'number (default: 20, max: 50)',
+      },
+      output: { tweets: 'XSearchResult[]' },
+    },
+  );
+  if (verified.response) return verified.response;
+
+  const handle = c.req.param('handle');
+  if (!handle) return c.json({ error: 'Missing handle in URL path' }, 400);
+
+  const limit = parseLimit(c.req.query('limit'), 20, 50);
+  const proxy = getProxy();
+  const ip = await getProxyExitIp();
+  const tweets = await getXUserTweets(handle, limit);
+
+  c.header('X-Payment-Settled', 'true');
+  c.header('X-Payment-TxHash', verified.payment.txHash);
+
+  return c.json({
+    handle: handle.startsWith('@') ? handle : `@${handle}`,
+    tweets,
+    meta: {
+      total_results: tweets.length,
+      proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || 'mobile', type: 'mobile' },
+    },
+    payment: {
+      txHash: verified.payment.txHash,
+      network: verified.payment.network,
+      amount: verified.verification.amount,
+      settled: true,
+    },
+  });
+});
+
+xRouter.get('/thread/:tweet_id', async (c) => {
+  const verified = await verifyPaidRequest(
+    c,
+    PRICE_THREAD,
+    '/api/x/thread/:tweet_id',
+    'Extract root tweet + conversation context by tweet id.',
+    {
+      input: {
+        tweet_id: 'string (required, in URL path)',
+        limit: 'number (default: 20, max: 50)',
+      },
+      output: { thread: 'XThreadResult' },
+    },
+  );
+  if (verified.response) return verified.response;
+
+  const tweetId = c.req.param('tweet_id');
+  if (!tweetId) return c.json({ error: 'Missing tweet_id in URL path' }, 400);
+
+  const limit = parseLimit(c.req.query('limit'), 20, 50);
+  const proxy = getProxy();
+  const ip = await getProxyExitIp();
+  const thread = await getXThread(tweetId, limit);
+
+  c.header('X-Payment-Settled', 'true');
+  c.header('X-Payment-TxHash', verified.payment.txHash);
+
+  return c.json({
+    thread,
+    meta: {
+      proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || 'mobile', type: 'mobile' },
+    },
+    payment: {
+      txHash: verified.payment.txHash,
+      network: verified.payment.network,
+      amount: verified.verification.amount,
+      settled: true,
+    },
+  });
+});

--- a/src/scrapers/x-scraper.ts
+++ b/src/scrapers/x-scraper.ts
@@ -1,0 +1,232 @@
+import { proxyFetch } from '../proxy';
+import { getTwitterTrending, searchTwitter, type TwitterResult } from './twitter';
+
+export type XSortMode = 'latest' | 'top';
+
+export interface XSearchResult {
+  id: string | null;
+  author: {
+    handle: string | null;
+    name: string | null;
+    followers: number | null;
+    verified: boolean | null;
+  };
+  text: string;
+  created_at: string | null;
+  likes: number | null;
+  retweets: number | null;
+  replies: number | null;
+  views: number | null;
+  url: string;
+  media: string[];
+  hashtags: string[];
+}
+
+export interface XUserProfile {
+  handle: string;
+  name: string | null;
+  description: string | null;
+  followers: number | null;
+  following: number | null;
+  verified: boolean | null;
+  profile_image_url: string | null;
+}
+
+export interface XThreadResult {
+  id: string;
+  root_tweet: XSearchResult | null;
+  conversation: XSearchResult[];
+}
+
+interface FollowButtonUser {
+  screen_name?: unknown;
+  name?: unknown;
+  description?: unknown;
+  followers_count?: unknown;
+  friends_count?: unknown;
+  verified?: unknown;
+  profile_image_url_https?: unknown;
+}
+
+interface SyndicationTweet {
+  id_str?: unknown;
+  text?: unknown;
+  favorite_count?: unknown;
+  retweet_count?: unknown;
+  conversation_count?: unknown;
+  created_at?: unknown;
+  user?: {
+    screen_name?: unknown;
+    name?: unknown;
+    followers_count?: unknown;
+    verified?: unknown;
+  };
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const v = value.trim();
+  return v ? v : null;
+}
+
+function extractHashtags(text: string): string[] {
+  const tags = new Set<string>();
+  for (const match of text.matchAll(/#([A-Za-z0-9_]{1,50})/g)) {
+    tags.add(match[1].toLowerCase());
+  }
+  return Array.from(tags);
+}
+
+function mapTwitterResult(result: TwitterResult): XSearchResult {
+  return {
+    id: result.tweetId,
+    author: {
+      handle: result.author,
+      name: null,
+      followers: null,
+      verified: null,
+    },
+    text: result.text,
+    created_at: result.publishedAt,
+    likes: result.likes,
+    retweets: result.retweets,
+    replies: null,
+    views: null,
+    url: result.url,
+    media: [],
+    hashtags: extractHashtags(result.text),
+  };
+}
+
+function daysFromSort(sort: XSortMode): number {
+  return sort === 'latest' ? 7 : 30;
+}
+
+export async function searchX(query: string, sort: XSortMode, limit: number): Promise<XSearchResult[]> {
+  const rows = await searchTwitter(query, daysFromSort(sort), limit);
+  return rows.map(mapTwitterResult);
+}
+
+export async function getXTrending(country: string, limit: number): Promise<XSearchResult[]> {
+  const rows = await getTwitterTrending(country, limit);
+  return rows.map(mapTwitterResult);
+}
+
+export async function getXUser(handle: string): Promise<XUserProfile | null> {
+  const cleanHandle = handle.replace(/^@/, '').trim();
+  if (!cleanHandle) return null;
+
+  const url = `https://cdn.syndication.twimg.com/widgets/followbutton/info.json?screen_names=${encodeURIComponent(cleanHandle)}`;
+  const res = await proxyFetch(url, {
+    headers: { Accept: 'application/json' },
+    timeoutMs: 15_000,
+    maxRetries: 1,
+  });
+
+  if (!res.ok) return null;
+
+  const payload = await res.json() as unknown;
+  if (!Array.isArray(payload) || payload.length === 0 || typeof payload[0] !== 'object' || payload[0] === null) {
+    return null;
+  }
+
+  const user = payload[0] as FollowButtonUser;
+  const screenName = toStringOrNull(user.screen_name);
+  if (!screenName) return null;
+
+  return {
+    handle: `@${screenName}`,
+    name: toStringOrNull(user.name),
+    description: toStringOrNull(user.description),
+    followers: toNumber(user.followers_count),
+    following: toNumber(user.friends_count),
+    verified: typeof user.verified === 'boolean' ? user.verified : null,
+    profile_image_url: toStringOrNull(user.profile_image_url_https),
+  };
+}
+
+export async function getXUserTweets(handle: string, limit: number): Promise<XSearchResult[]> {
+  const cleanHandle = handle.replace(/^@/, '').trim();
+  if (!cleanHandle) return [];
+
+  const rows = await searchTwitter(`from:${cleanHandle}`, 7, limit);
+  return rows.map((row) => {
+    const mapped = mapTwitterResult(row);
+    if (!mapped.author.handle) {
+      mapped.author.handle = `@${cleanHandle}`;
+    }
+    return mapped;
+  });
+}
+
+function mapSyndicationTweet(tweet: SyndicationTweet): XSearchResult | null {
+  const id = toStringOrNull(tweet.id_str);
+  const text = toStringOrNull(tweet.text);
+  if (!id || !text) return null;
+
+  const handle = toStringOrNull(tweet.user?.screen_name);
+  const profileName = toStringOrNull(tweet.user?.name);
+
+  return {
+    id,
+    author: {
+      handle: handle ? `@${handle}` : null,
+      name: profileName,
+      followers: toNumber(tweet.user?.followers_count),
+      verified: typeof tweet.user?.verified === 'boolean' ? tweet.user.verified : null,
+    },
+    text,
+    created_at: toStringOrNull(tweet.created_at),
+    likes: toNumber(tweet.favorite_count),
+    retweets: toNumber(tweet.retweet_count),
+    replies: toNumber(tweet.conversation_count),
+    views: null,
+    url: handle ? `https://x.com/${handle}/status/${id}` : `https://x.com/i/web/status/${id}`,
+    media: [],
+    hashtags: extractHashtags(text),
+  };
+}
+
+export async function getXThread(tweetId: string, limit: number): Promise<XThreadResult> {
+  const cleanTweetId = tweetId.replace(/\D/g, '');
+  const fallback: XThreadResult = { id: cleanTweetId || tweetId, root_tweet: null, conversation: [] };
+  if (!cleanTweetId) return fallback;
+
+  let rootTweet: XSearchResult | null = null;
+  try {
+    const syndicationUrl = `https://cdn.syndication.twimg.com/tweet-result?id=${encodeURIComponent(cleanTweetId)}&lang=en`;
+    const res = await proxyFetch(syndicationUrl, {
+      headers: { Accept: 'application/json' },
+      timeoutMs: 15_000,
+      maxRetries: 1,
+    });
+
+    if (res.ok) {
+      const payload = await res.json() as SyndicationTweet;
+      rootTweet = mapSyndicationTweet(payload);
+    }
+  } catch {
+    rootTweet = null;
+  }
+
+  const related = await searchTwitter(cleanTweetId, 7, Math.max(limit, 5));
+  const mappedRelated = related
+    .map(mapTwitterResult)
+    .filter((row) => row.id !== cleanTweetId)
+    .slice(0, limit);
+
+  return {
+    id: cleanTweetId,
+    root_tweet: rootTweet,
+    conversation: mappedRelated,
+  };
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -20,6 +20,7 @@ import { fetchReviews, fetchBusinessDetails, fetchReviewSummary, searchBusinesse
 import { scrapeGoogleMaps, extractDetailedBusiness } from './scrapers/maps-scraper';
 import { researchRouter } from './routes/research';
 import { trendingRouter } from './routes/trending';
+import { xRouter } from './routes/x';
 import { searchAirbnb, getListingDetail, getListingReviews, getMarketStats } from './scrapers/airbnb-scraper';
 import { 
   scrapeLinkedInPerson, 
@@ -35,6 +36,7 @@ export const serviceRouter = new Hono();
 // ─── TREND INTELLIGENCE ROUTES (Bounty #70) ─────────
 serviceRouter.route('/research', researchRouter);
 serviceRouter.route('/trending', trendingRouter);
+serviceRouter.route('/x', xRouter);
 
 const SERVICE_NAME = 'job-market-intelligence';
 const PRICE_USDC = 0.005;

--- a/tests/x-endpoints.test.ts
+++ b/tests/x-endpoints.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x2222222222222222222222222222222222222222';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+let txCounter = 2000;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function installFetchMock(recipientAddress: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(recipientAddress),
+            ],
+            data: '0x000000000000000000000000000000000000000000000000000000000007a120', // 0.5 USDC
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://api.ipify.org')) {
+      return new Response(JSON.stringify({ ip: '198.51.100.55' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.includes('100.91.53.54:8890/search')) {
+      return new Response(JSON.stringify({
+        results: [
+          {
+            url: 'https://x.com/openclaw/status/1234567890',
+            title: 'OpenClaw launch thread',
+            content: 'OpenClaw is shipping fast #OpenClaw #Agents',
+            score: 0.91,
+            publishedDate: '2026-03-05T10:00:00Z',
+          },
+          {
+            url: 'https://x.com/openclaw/status/1234567891',
+            title: 'Agent updates',
+            content: 'New automation capabilities are live #AI',
+            score: 0.88,
+            publishedDate: '2026-03-05T11:00:00Z',
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://cdn.syndication.twimg.com/widgets/followbutton/info.json')) {
+      return new Response(JSON.stringify([
+        {
+          screen_name: 'openclaw',
+          name: 'OpenClaw',
+          description: 'Agent automation runtime',
+          followers_count: 4200,
+          friends_count: 120,
+          verified: false,
+          profile_image_url_https: 'https://pbs.twimg.com/profile_images/openclaw.jpg',
+        },
+      ]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://cdn.syndication.twimg.com/tweet-result')) {
+      return new Response(JSON.stringify({
+        id_str: '1234567890',
+        text: 'Root tweet body #OpenClaw',
+        favorite_count: 10,
+        retweet_count: 3,
+        conversation_count: 2,
+        created_at: '2026-03-05T09:55:00Z',
+        user: {
+          screen_name: 'openclaw',
+          name: 'OpenClaw',
+          followers_count: 4200,
+          verified: false,
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in X endpoint test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+  process.env.PROXY_CARRIER = 'T-Mobile';
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('X/Twitter endpoints', () => {
+  test('GET /api/x/search returns 402 when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/x/search?query=openclaw'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.resource).toBe('/api/x/search');
+    expect(body.price.amount).toBe('0.01');
+  });
+
+  test('GET /api/x/search returns search results for paid request', async () => {
+    const calls = installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/x/search?query=openclaw&limit=2', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Payment-Settled')).toBe('true');
+    expect(calls.some((url) => url.includes('mainnet.base.org'))).toBe(true);
+    expect(calls.some((url) => url.includes('100.91.53.54:8890/search'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.results.length).toBeGreaterThan(0);
+    expect(body.results[0].url).toContain('x.com');
+    expect(body.results[0].hashtags).toContain('openclaw');
+    expect(body.payment.txHash).toBe(txHash);
+  });
+
+  test('GET /api/x/user/:handle returns profile data for paid request', async () => {
+    const calls = installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/x/user/openclaw', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(calls.some((url) => url.startsWith('https://cdn.syndication.twimg.com/widgets/followbutton/info.json'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.user.handle).toBe('@openclaw');
+    expect(body.user.followers).toBe(4200);
+    expect(body.user.description).toContain('automation');
+  });
+
+  test('GET /api/x/thread/:tweet_id returns root tweet + conversation', async () => {
+    const calls = installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/x/thread/1234567890?limit=2', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(calls.some((url) => url.startsWith('https://cdn.syndication.twimg.com/tweet-result'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.thread.id).toBe('1234567890');
+    expect(body.thread.root_tweet.id).toBe('1234567890');
+    expect(Array.isArray(body.thread.conversation)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated `/api/x/*` endpoint group for X/Twitter intelligence:
  - `GET /api/x/search`
  - `GET /api/x/trending`
  - `GET /api/x/user/:handle`
  - `GET /api/x/user/:handle/tweets`
  - `GET /api/x/thread/:tweet_id`
- add `x-scraper` module that wraps existing Twitter search/trending logic and adds profile/thread extraction via X syndication endpoints
- include x402 payment verification + proxy metadata in responses
- register new endpoints in `service.ts` and surface them in root/health endpoint docs
- add end-to-end tests for X endpoints (`tests/x-endpoints.test.ts`)

## Testing
- `bun test`
- `bun run typecheck`

Fixes #73
