### PR TITLE
feat: add Facebook Marketplace monitor API endpoints

### DIFF
--- a/listings/facebook-marketplace-monitor.json
+++ b/listings/facebook-marketplace-monitor.json
@@ -1,0 +1,45 @@
+{
+  "name": "Facebook Marketplace Monitor API",
+  "description": "Search and monitor Facebook Marketplace listings by keyword/location/price with mobile-proxy routing and x402 micropayments.",
+  "version": "1.0.0",
+  "price": {
+    "search": 0.01,
+    "listing": 0.005,
+    "new": 0.02
+  },
+  "endpoints": [
+    {
+      "path": "/api/marketplace/search",
+      "method": "GET",
+      "price": 0.01,
+      "description": "Search listings by keyword, location, category, and price range",
+      "params": ["query", "location?", "category?", "radius?", "min_price?", "max_price?", "limit?"]
+    },
+    {
+      "path": "/api/marketplace/listing/:id",
+      "method": "GET",
+      "price": 0.005,
+      "description": "Fetch listing detail by Marketplace listing ID",
+      "params": ["id"]
+    },
+    {
+      "path": "/api/marketplace/categories",
+      "method": "GET",
+      "price": 0,
+      "description": "List Marketplace categories (location-aware best effort)",
+      "params": ["location?"]
+    },
+    {
+      "path": "/api/marketplace/new",
+      "method": "GET",
+      "price": 0.02,
+      "description": "Monitor newly posted listings within a timeframe",
+      "params": ["query", "since?", "location?", "limit?"]
+    }
+  ],
+  "wallet": "6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv",
+  "bounty": {
+    "issue": "https://github.com/bolivian-peru/marketplace-service-template/issues/75",
+    "amount": "$75 in $SX token"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,10 @@ app.get('/health', (c) => c.json({
     '/api/airbnb/listing/:id',
     '/api/airbnb/reviews/:listing_id',
     '/api/airbnb/market-stats',
+    '/api/marketplace/search',
+    '/api/marketplace/listing/:id',
+    '/api/marketplace/categories',
+    '/api/marketplace/new',
   ],
 }));
 
@@ -95,6 +99,10 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/reviews/:place_id', description: 'Fetch Google reviews by Place ID', price: '0.02 USDC' },
     { method: 'GET', path: '/api/business/:place_id', description: 'Get business details + review summary', price: '0.01 USDC' },
     { method: 'GET', path: '/api/reviews/summary/:place_id', description: 'Get review summary stats', price: '0.005 USDC' },
+    { method: 'GET', path: '/api/marketplace/search', description: 'Search Facebook Marketplace listings by keyword/location/price', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/marketplace/listing/:id', description: 'Get Facebook Marketplace listing details', price: '0.005 USDC' },
+    { method: 'GET', path: '/api/marketplace/categories', description: 'List Facebook Marketplace categories (location-aware best effort)', price: 'free' },
+    { method: 'GET', path: '/api/marketplace/new', description: 'Monitor newly posted Marketplace listings by timeframe', price: '0.02 USDC' },
   ],
   pricing: {
     amount: process.env.PRICE_USDC || '0.005',
@@ -128,7 +136,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/marketplace/search', '/api/marketplace/listing/:id', '/api/marketplace/categories', '/api/marketplace/new'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/scrapers/facebook-marketplace.ts
+++ b/src/scrapers/facebook-marketplace.ts
@@ -1,0 +1,315 @@
+import { proxyFetch } from '../proxy';
+
+export interface MarketplaceSeller {
+  name: string | null;
+  joined: string | null;
+  rating: string | null;
+}
+
+export interface MarketplaceListing {
+  id: string;
+  title: string;
+  price: number | null;
+  currency: string;
+  location: string | null;
+  seller: MarketplaceSeller;
+  condition: string | null;
+  posted_at: string | null;
+  images: string[];
+  url: string;
+}
+
+export interface MarketplaceSearchParams {
+  query: string;
+  location?: string;
+  category?: string;
+  radius?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  limit?: number;
+}
+
+const FB_MOBILE_BASE = 'https://m.facebook.com';
+
+function decodeHtml(value: string): string {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&#39;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('\\/', '/');
+}
+
+function parsePrice(raw: string | null): { amount: number | null; currency: string } {
+  if (!raw) return { amount: null, currency: 'USD' };
+  const normalized = raw.replace(/\s+/g, ' ').trim();
+
+  const currency = normalized.includes('€')
+    ? 'EUR'
+    : normalized.includes('£')
+      ? 'GBP'
+      : 'USD';
+
+  const numberText = normalized.replace(/[^0-9.,]/g, '').replace(/,/g, '');
+  if (!numberText) return { amount: null, currency };
+
+  const amount = Number.parseFloat(numberText);
+  return { amount: Number.isFinite(amount) ? amount : null, currency };
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function relativeTimeToIso(value: string | null): string | null {
+  if (!value) return null;
+  const text = value.toLowerCase().trim();
+
+  const now = Date.now();
+  if (text === 'just now') return new Date(now).toISOString();
+  if (text === 'yesterday') return new Date(now - 24 * 60 * 60 * 1000).toISOString();
+
+  const shortMatch = text.match(/(\d+)\s*([smhdw])\b/);
+  if (shortMatch) {
+    const valueNum = Number.parseInt(shortMatch[1], 10);
+    const unit = shortMatch[2];
+    if (!Number.isFinite(valueNum)) return null;
+
+    const multiplier = unit === 's'
+      ? 1000
+      : unit === 'm'
+        ? 60_000
+        : unit === 'h'
+          ? 3_600_000
+          : unit === 'd'
+            ? 86_400_000
+            : 604_800_000;
+
+    return new Date(now - valueNum * multiplier).toISOString();
+  }
+
+  const longMatch = text.match(/(\d+)\s*(second|minute|hour|day|week|month|year)s?\s+ago/);
+  if (!longMatch) return null;
+
+  const valueNum = Number.parseInt(longMatch[1], 10);
+  if (!Number.isFinite(valueNum)) return null;
+
+  const unit = longMatch[2];
+  const multiplier = unit === 'second'
+    ? 1000
+    : unit === 'minute'
+      ? 60_000
+      : unit === 'hour'
+        ? 3_600_000
+        : unit === 'day'
+          ? 86_400_000
+          : unit === 'week'
+            ? 604_800_000
+            : unit === 'month'
+              ? 2_592_000_000
+              : 31_536_000_000;
+
+  return new Date(now - valueNum * multiplier).toISOString();
+}
+
+function parseSeller(text: string): MarketplaceSeller {
+  const sellerNameMatch = text.match(/seller(?:name)?["':\s]+([a-zA-Z0-9 ._-]{2,60})/i);
+  const joinedMatch = text.match(/joined["':\s]+([a-zA-Z0-9 ,]{2,30})/i);
+  const ratingMatch = text.match(/rating["':\s]+([0-9.]+\/?5(?:\s*stars?)?)/i);
+
+  return {
+    name: sellerNameMatch ? normalizeWhitespace(sellerNameMatch[1]) : null,
+    joined: joinedMatch ? normalizeWhitespace(joinedMatch[1]) : null,
+    rating: ratingMatch ? normalizeWhitespace(ratingMatch[1]) : null,
+  };
+}
+
+function parseListingChunk(id: string, chunk: string): MarketplaceListing {
+  const titleMatch = chunk.match(/(?:"title"|aria-label|data-title)[=:"]+([^"<>{]{3,160})/i);
+  const locationMatch = chunk.match(/(?:"location"|data-location)[=:"]+([^"<>{]{2,120})/i);
+  const conditionMatch = chunk.match(/(?:"condition"|data-condition)[=:"]+([^"<>{]{2,120})/i);
+
+  const postedFromShort = chunk.match(/(\d+\s*[smhdw])\b/i)?.[1] ?? null;
+  const postedFromAgo = chunk.match(/(\d+\s*(?:minute|hour|day|week|month|year)s?\s+ago)/i)?.[1] ?? null;
+  const postedFromYesterday = /\byesterday\b/i.test(chunk) ? 'yesterday' : null;
+  const postedRaw = postedFromShort || postedFromAgo || postedFromYesterday;
+
+  const imageMatches = Array.from(chunk.matchAll(/https?:\/\/[^"'\s]+\.(?:jpg|jpeg|png|webp)/gi)).map((m) =>
+    decodeHtml(m[0]).replace(/\\\//g, '/'),
+  );
+
+  const priceMatch = chunk.match(/(?:"price"|"formatted_amount"|data-price)[=:"]+([^"<>{]{1,60})/i) ||
+    chunk.match(/([$€£]\s?[0-9][0-9,\.]{0,15})/);
+  const parsedPrice = parsePrice(priceMatch ? decodeHtml(priceMatch[1] ?? priceMatch[0]) : null);
+
+  return {
+    id,
+    title: titleMatch ? normalizeWhitespace(decodeHtml(titleMatch[1])) : `Marketplace Listing ${id}`,
+    price: parsedPrice.amount,
+    currency: parsedPrice.currency,
+    location: locationMatch ? normalizeWhitespace(decodeHtml(locationMatch[1])) : null,
+    seller: parseSeller(chunk),
+    condition: conditionMatch ? normalizeWhitespace(decodeHtml(conditionMatch[1])) : null,
+    posted_at: relativeTimeToIso(postedRaw),
+    images: imageMatches.slice(0, 6),
+    url: `https://facebook.com/marketplace/item/${id}`,
+  };
+}
+
+function extractListings(html: string, limit: number): MarketplaceListing[] {
+  const matches = Array.from(html.matchAll(/\/marketplace\/item\/(\d{6,})/g));
+  const seen = new Set<string>();
+  const listings: MarketplaceListing[] = [];
+
+  for (const match of matches) {
+    const id = match[1];
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const start = Math.max(0, (match.index ?? 0) - 120);
+    const end = Math.min(html.length, (match.index ?? 0) + 700);
+    const chunk = html.slice(start, end);
+
+    listings.push(parseListingChunk(id, chunk));
+    if (listings.length >= limit) break;
+  }
+
+  return listings;
+}
+
+function parseSinceWindowMs(since: string): number {
+  const normalized = since.trim().toLowerCase();
+  const match = normalized.match(/^(\d+)\s*(s|m|h|d|w)$/);
+  if (!match) return 3_600_000;
+
+  const value = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(value) || value < 1) return 3_600_000;
+
+  const unit = match[2];
+  if (unit === 's') return value * 1000;
+  if (unit === 'm') return value * 60_000;
+  if (unit === 'h') return value * 3_600_000;
+  if (unit === 'd') return value * 86_400_000;
+  return value * 604_800_000;
+}
+
+function buildSearchUrl(params: MarketplaceSearchParams): string {
+  const searchParams = new URLSearchParams();
+  searchParams.set('query', params.query);
+
+  if (params.location) searchParams.set('location', params.location);
+  if (params.category) searchParams.set('category', params.category);
+  if (params.radius) searchParams.set('radius', params.radius);
+  if (typeof params.minPrice === 'number') searchParams.set('minPrice', String(Math.max(0, params.minPrice)));
+  if (typeof params.maxPrice === 'number') searchParams.set('maxPrice', String(Math.max(0, params.maxPrice)));
+
+  return `${FB_MOBILE_BASE}/marketplace/search/?${searchParams.toString()}`;
+}
+
+export async function searchMarketplace(params: MarketplaceSearchParams): Promise<MarketplaceListing[]> {
+  const limit = Math.min(Math.max(params.limit ?? 20, 1), 50);
+  const res = await proxyFetch(buildSearchUrl(params), {
+    timeoutMs: 30_000,
+    headers: {
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Sec-Fetch-Dest': 'document',
+      'Sec-Fetch-Mode': 'navigate',
+      'Sec-Fetch-Site': 'none',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Marketplace search failed with status ${res.status}`);
+  }
+
+  const html = await res.text();
+  return extractListings(html, limit);
+}
+
+export async function getMarketplaceListing(listingId: string): Promise<MarketplaceListing | null> {
+  const normalizedId = listingId.replace(/\D/g, '');
+  if (!normalizedId) return null;
+
+  const res = await proxyFetch(`${FB_MOBILE_BASE}/marketplace/item/${normalizedId}/`, {
+    timeoutMs: 30_000,
+    headers: {
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Sec-Fetch-Dest': 'document',
+      'Sec-Fetch-Mode': 'navigate',
+      'Sec-Fetch-Site': 'none',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Marketplace listing fetch failed with status ${res.status}`);
+  }
+
+  const html = await res.text();
+  const listings = extractListings(html, 1);
+  if (listings.length > 0) {
+    return { ...listings[0], id: normalizedId, url: `https://facebook.com/marketplace/item/${normalizedId}` };
+  }
+
+  return {
+    id: normalizedId,
+    title: `Marketplace Listing ${normalizedId}`,
+    price: null,
+    currency: 'USD',
+    location: null,
+    seller: { name: null, joined: null, rating: null },
+    condition: null,
+    posted_at: null,
+    images: [],
+    url: `https://facebook.com/marketplace/item/${normalizedId}`,
+  };
+}
+
+export async function listMarketplaceCategories(location?: string): Promise<string[]> {
+  const url = `${FB_MOBILE_BASE}/marketplace/${location ? `?location=${encodeURIComponent(location)}` : ''}`;
+
+  try {
+    const res = await proxyFetch(url, {
+      timeoutMs: 20_000,
+      maxRetries: 1,
+      headers: { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' },
+    });
+
+    if (res.ok) {
+      const html = await res.text();
+      const dynamic = Array.from(html.matchAll(/\/marketplace\/category\/([a-z0-9_-]+)/gi)).map((m) => m[1].replaceAll('-', ' '));
+      const deduped = Array.from(new Set(dynamic.map((value) => normalizeWhitespace(value)))).filter(Boolean);
+      if (deduped.length > 0) return deduped.slice(0, 25);
+    }
+  } catch {
+    // fall through to defaults
+  }
+
+  return [
+    'vehicles',
+    'property rentals',
+    'electronics',
+    'home goods',
+    'apparel',
+    'family',
+    'hobbies',
+    'classifieds',
+  ];
+}
+
+export async function monitorNewMarketplaceListings(
+  query: string,
+  since: string,
+  location?: string,
+  limit: number = 30,
+): Promise<MarketplaceListing[]> {
+  const listings = await searchMarketplace({ query, location, limit });
+  const cutoff = Date.now() - parseSinceWindowMs(since);
+
+  return listings.filter((listing) => {
+    if (!listing.posted_at) return false;
+    const timestamp = Date.parse(listing.posted_at);
+    return Number.isFinite(timestamp) && timestamp >= cutoff;
+  });
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,6 +9,7 @@
  *   GET /api/airbnb/*  (Airbnb Market Intelligence)
  *   GET /api/reddit/*  (Reddit Intelligence)
  *   GET /api/instagram/* (Instagram Intelligence + AI Vision)
+ *   GET /api/marketplace/* (Facebook Marketplace Monitor)
  *   GET /api/linkedin/* (LinkedIn Enrichment)
  */
 
@@ -29,6 +30,12 @@ import {
 } from './scrapers/linkedin-enrichment';
 import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile } from './scrapers/instagram-scraper';
 import { searchReddit, getSubreddit, getTrending, getComments } from './scrapers/reddit-scraper';
+import {
+  searchMarketplace,
+  getMarketplaceListing,
+  listMarketplaceCategories,
+  monitorNewMarketplaceListings,
+} from './scrapers/facebook-marketplace';
 
 export const serviceRouter = new Hono();
 
@@ -547,6 +554,222 @@ serviceRouter.get('/business/:place_id', async (c) => {
     });
   } catch (err: any) {
     return c.json({ error: 'Business details fetch failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ═══════════════════════════════════════════════════════
+// ─── FACEBOOK MARKETPLACE MONITOR API (Bounty #75) ────
+// ═══════════════════════════════════════════════════════
+
+const MARKETPLACE_SEARCH_PRICE_USDC = 0.01;
+const MARKETPLACE_LISTING_PRICE_USDC = 0.005;
+const MARKETPLACE_NEW_PRICE_USDC = 0.02;
+
+// ─── GET /api/marketplace/search ─────────────────────
+
+serviceRouter.get('/marketplace/search', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/marketplace/search', 'Search Facebook Marketplace listings by keyword/location/price filters', MARKETPLACE_SEARCH_PRICE_USDC, walletAddress, {
+      input: {
+        query: 'string (required)',
+        location: 'string (optional)',
+        category: 'string (optional)',
+        radius: 'string (optional, e.g. 25mi)',
+        min_price: 'number (optional)',
+        max_price: 'number (optional)',
+        limit: 'number (optional, default 20, max 50)',
+      },
+      output: {
+        results: 'MarketplaceListing[]',
+        meta: '{ query, total_results, proxy, filters }',
+      },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, MARKETPLACE_SEARCH_PRICE_USDC);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const query = c.req.query('query');
+  if (!query) {
+    return c.json({
+      error: 'Missing required parameter: query',
+      example: '/api/marketplace/search?query=iphone+15&location=New+York&min_price=500&max_price=1000',
+    }, 400);
+  }
+
+  const minPriceRaw = c.req.query('min_price');
+  const maxPriceRaw = c.req.query('max_price');
+  const minPrice = minPriceRaw !== undefined ? Number.parseFloat(minPriceRaw) : undefined;
+  const maxPrice = maxPriceRaw !== undefined ? Number.parseFloat(maxPriceRaw) : undefined;
+
+  if (minPriceRaw !== undefined && !Number.isFinite(minPrice)) {
+    return c.json({ error: 'Invalid min_price parameter: must be a number' }, 400);
+  }
+
+  if (maxPriceRaw !== undefined && !Number.isFinite(maxPrice)) {
+    return c.json({ error: 'Invalid max_price parameter: must be a number' }, 400);
+  }
+
+  if (minPrice !== undefined && maxPrice !== undefined && minPrice > maxPrice) {
+    return c.json({ error: 'Invalid price range: min_price cannot be greater than max_price' }, 400);
+  }
+
+  const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '20') || 20, 1), 50);
+
+  try {
+    const proxy = getProxy();
+    const ip = await getProxyExitIp();
+    const results = await searchMarketplace({
+      query,
+      location: c.req.query('location') || undefined,
+      category: c.req.query('category') || undefined,
+      radius: c.req.query('radius') || undefined,
+      minPrice,
+      maxPrice,
+      limit,
+    });
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      results,
+      meta: {
+        query,
+        total_results: results.length,
+        filters: {
+          location: c.req.query('location') || null,
+          category: c.req.query('category') || null,
+          radius: c.req.query('radius') || null,
+          min_price: minPrice ?? null,
+          max_price: maxPrice ?? null,
+        },
+        proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || null, type: 'mobile' },
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'Marketplace search failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ─── GET /api/marketplace/listing/:id ───────────────
+
+serviceRouter.get('/marketplace/listing/:id', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/marketplace/listing/:id', 'Get Facebook Marketplace listing details by listing ID', MARKETPLACE_LISTING_PRICE_USDC, walletAddress, {
+      input: { id: 'string (required) — marketplace listing ID' },
+      output: { listing: 'MarketplaceListing' },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, MARKETPLACE_LISTING_PRICE_USDC);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const listingId = c.req.param('id');
+  if (!listingId) return c.json({ error: 'Missing listing ID in URL path' }, 400);
+
+  try {
+    const proxy = getProxy();
+    const ip = await getProxyExitIp();
+    const listing = await getMarketplaceListing(listingId);
+
+    if (!listing) {
+      return c.json({ error: 'Listing not found or inaccessible' }, 404);
+    }
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      listing,
+      meta: { proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || null, type: 'mobile' } },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'Marketplace listing fetch failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ─── GET /api/marketplace/categories ────────────────
+
+serviceRouter.get('/marketplace/categories', async (c) => {
+  try {
+    const categories = await listMarketplaceCategories(c.req.query('location') || undefined);
+    return c.json({
+      categories,
+      meta: {
+        location: c.req.query('location') || null,
+        total_categories: categories.length,
+      },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'Marketplace categories fetch failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ─── GET /api/marketplace/new ───────────────────────
+
+serviceRouter.get('/marketplace/new', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/marketplace/new', 'Monitor newly posted Facebook Marketplace listings within a rolling time window', MARKETPLACE_NEW_PRICE_USDC, walletAddress, {
+      input: {
+        query: 'string (required)',
+        since: 'string (optional, default: 1h, format: 15m|1h|2d)',
+        location: 'string (optional)',
+        limit: 'number (optional, default 30, max 50)',
+      },
+      output: { results: 'MarketplaceListing[]', meta: '{ query, since, new_count, proxy }' },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, MARKETPLACE_NEW_PRICE_USDC);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const query = c.req.query('query');
+  if (!query) {
+    return c.json({ error: 'Missing required parameter: query', example: '/api/marketplace/new?query=iphone&since=1h' }, 400);
+  }
+
+  const since = c.req.query('since') || '1h';
+  if (!/^\d+\s*[smhdw]$/i.test(since)) {
+    return c.json({ error: 'Invalid since parameter. Use formats like 30m, 1h, 2d, 1w' }, 400);
+  }
+
+  const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '30') || 30, 1), 50);
+
+  try {
+    const proxy = getProxy();
+    const ip = await getProxyExitIp();
+    const results = await monitorNewMarketplaceListings(query, since, c.req.query('location') || undefined, limit);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      results,
+      meta: {
+        query,
+        since,
+        new_count: results.length,
+        proxy: { ip, country: proxy.country, carrier: process.env.PROXY_CARRIER || null, type: 'mobile' },
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'Marketplace monitor failed', message: err?.message || String(err) }, 502);
   }
 });
 

--- a/tests/marketplace-endpoints.test.ts
+++ b/tests/marketplace-endpoints.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x2222222222222222222222222222222222222222';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+let txCounter = 4000;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function installFetchMock(recipientAddress: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(recipientAddress),
+            ],
+            data: '0x00000000000000000000000000000000000000000000000000000000000f4240', // 1.0 USDC
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://api.ipify.org')) {
+      return new Response(JSON.stringify({ ip: '203.0.113.50' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.includes('m.facebook.com/marketplace/search/')) {
+      return new Response(`
+        <html><body>
+          <div class="listing">
+            <a href="/marketplace/item/111111111111111/" data-title="iPhone 15 Pro Max 256GB" data-price="$850" data-location="Brooklyn, NY" data-condition="Used - Like New">
+              2h ago seller name John D. joined 2019 rating 5/5
+              <img src="https://cdn.example.com/iphone-15.jpg" />
+            </a>
+          </div>
+          <div class="listing">
+            <a href="/marketplace/item/222222222222222/" data-title="iPhone 14" data-price="$600" data-location="Queens, NY" data-condition="Used - Good">
+              2d ago seller name Alex P. joined 2020 rating 4.8/5
+              <img src="https://cdn.example.com/iphone-14.jpg" />
+            </a>
+          </div>
+        </body></html>
+      `, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    if (url.includes('m.facebook.com/marketplace/item/111111111111111/')) {
+      return new Response(`
+        <html><body>
+          <main>
+            <a href="/marketplace/item/111111111111111/" data-title="iPhone 15 Pro Max 256GB" data-price="$850" data-location="Brooklyn, NY" data-condition="Used - Like New">
+              1h ago seller name John D. joined 2019 rating 5/5
+              <img src="https://cdn.example.com/iphone-15.jpg" />
+            </a>
+          </main>
+        </body></html>
+      `, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    if (url === 'https://m.facebook.com/marketplace/?location=New%20York') {
+      return new Response(`
+        <html><body>
+          <a href="/marketplace/category/electronics">Electronics</a>
+          <a href="/marketplace/category/property-rentals">Property Rentals</a>
+          <a href="/marketplace/category/vehicles">Vehicles</a>
+        </body></html>
+      `, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in marketplace endpoint test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+  process.env.PROXY_CARRIER = 'Verizon';
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('Facebook Marketplace endpoints', () => {
+  test('GET /api/marketplace/search returns 402 when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/marketplace/search?query=iphone'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.resource).toBe('/api/marketplace/search');
+    expect(body.price.amount).toBe('0.01');
+  });
+
+  test('GET /api/marketplace/search returns structured listings for paid request', async () => {
+    const calls = installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/marketplace/search?query=iphone+15&location=New+York&min_price=500&max_price=1000&limit=2', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(calls.some((url) => url.includes('mainnet.base.org'))).toBe(true);
+    expect(calls.some((url) => url.includes('m.facebook.com/marketplace/search/'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.results.length).toBeGreaterThan(0);
+    expect(body.results[0].id).toBe('111111111111111');
+    expect(body.results[0].title).toContain('iPhone 15');
+    expect(body.results[0].price).toBe(850);
+    expect(body.meta.proxy.country).toBe('US');
+    expect(body.payment.txHash).toBe(txHash);
+  });
+
+  test('GET /api/marketplace/listing/:id returns listing detail for paid request', async () => {
+    const calls = installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/marketplace/listing/111111111111111', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(calls.some((url) => url.includes('/marketplace/item/111111111111111/'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.listing.id).toBe('111111111111111');
+    expect(body.listing.title).toContain('iPhone 15');
+    expect(body.listing.location).toBe('Brooklyn, NY');
+  });
+
+  test('GET /api/marketplace/categories returns parsed categories without payment', async () => {
+    installFetchMock(TEST_WALLET);
+
+    const res = await app.fetch(new Request('http://localhost/api/marketplace/categories?location=New%20York'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(Array.isArray(body.categories)).toBe(true);
+    expect(body.categories).toContain('electronics');
+    expect(body.categories).toContain('property rentals');
+  });
+
+  test('GET /api/marketplace/new filters listings by time window', async () => {
+    installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/marketplace/new?query=iphone&since=4h', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as any;
+    expect(body.results.length).toBeGreaterThanOrEqual(1);
+    expect(body.results.every((item: any) => item.id !== '222222222222222')).toBe(true);
+    expect(body.meta.new_count).toBe(body.results.length);
+  });
+});


### PR DESCRIPTION
## Summary
Implements bounty #75 with a full Facebook Marketplace monitor surface under `/api/marketplace/*` and wires each paid endpoint through the existing x402 flow.

### Added endpoints
- `GET /api/marketplace/search` ($0.01)
- `GET /api/marketplace/listing/:id` ($0.005)
- `GET /api/marketplace/categories` (free helper)
- `GET /api/marketplace/new` ($0.02)

### What was implemented
- New scraper module: `src/scrapers/facebook-marketplace.ts`
  - mobile-proxy routed search + listing fetches
  - listing extraction (id/title/price/location/condition/seller/images)
  - relative-time normalization for "new listings" monitoring
  - category discovery with fallback catalog
- Service integration in `src/service.ts`
  - full x402 payment gating for paid endpoints
  - query validation (price bounds, since format, required fields)
  - proxy metadata in response
- API surface docs update in `src/index.ts`
- Listing metadata file: `listings/facebook-marketplace-monitor.json`
- Test coverage: `tests/marketplace-endpoints.test.ts`

## Validation
- `bun test` ✅
- `bun run typecheck` ✅

Closes #75
