### PR TITLE
feat: Airbnb & short-term rental intelligence API

### DIFF
--- a/src/scrapers/airbnb-scraper.ts
+++ b/src/scrapers/airbnb-scraper.ts
@@ -62,6 +62,8 @@ export interface MarketStats {
   total_listings: number;
   avg_rating: number | null;
   superhost_pct: number | null;
+  avg_occupancy_estimate: number | null;
+  monthly_revenue_potential: number | null;
   price_distribution: {
     under_100: number;
     range_100_200: number;
@@ -70,6 +72,15 @@ export interface MarketStats {
     over_500: number;
   };
   property_types: Record<string, number>;
+}
+
+export interface SearchAirbnbOptions {
+  checkin?: string;
+  checkout?: string;
+  guests?: number;
+  priceMin?: number;
+  priceMax?: number;
+  limit?: number;
 }
 
 // ─── HELPERS ────────────────────────────────────────
@@ -149,10 +160,6 @@ async function fetchAirbnbApi(path: string, params: Record<string, string> = {})
 
 function parseListingFromHtml(html: string): AirbnbListing[] {
   const listings: AirbnbListing[] = [];
-
-  // Airbnb embeds listing data in a JSON script tag
-  const jsonMatch = html.match(/<!--(.*?)-->/s);
-  const dataScript = extractBetween(html, 'data-deferred-state-0="', '"');
 
   // Try to find listing data in the page's embedded JSON
   // Look for the StaySearchResults data
@@ -278,30 +285,31 @@ function parseListingData(listing: any, pricing?: any): AirbnbListing {
   };
 }
 
-export async function searchAirbnb(
-  location: string,
-  checkin?: string,
-  checkout?: string,
-  guests: number = 2,
-  priceMin?: number,
-  priceMax?: number,
-  limit: number = 20,
-): Promise<AirbnbListing[]> {
+export async function searchAirbnb(location: string, options: SearchAirbnbOptions = {}): Promise<AirbnbListing[]> {
+  const {
+    checkin,
+    checkout,
+    guests = 2,
+    priceMin,
+    priceMax,
+    limit = 20,
+  } = options;
+
   // Build search URL
-  let url = `${AIRBNB_BASE}/s/${encodeURIComponent(location)}/homes`;
+  const url = `${AIRBNB_BASE}/s/${encodeURIComponent(location)}/homes`;
   const params = new URLSearchParams();
   if (checkin) params.set('checkin', checkin);
   if (checkout) params.set('checkout', checkout);
   params.set('adults', String(Math.max(1, guests)));
-  if (priceMin) params.set('price_min', String(priceMin));
-  if (priceMax) params.set('price_max', String(priceMax));
+  if (priceMin !== undefined) params.set('price_min', String(priceMin));
+  if (priceMax !== undefined) params.set('price_max', String(priceMax));
   params.set('search_type', 'filter_change');
 
   const fullUrl = `${url}?${params.toString()}`;
   const html = await fetchAirbnbPage(fullUrl);
   const listings = parseListingFromHtml(html);
 
-  return listings.slice(0, limit);
+  return listings.slice(0, Math.max(1, limit));
 }
 
 // ─── LISTING DETAIL SCRAPER ─────────────────────────
@@ -525,7 +533,7 @@ export async function getMarketStats(
   checkout?: string,
 ): Promise<MarketStats> {
   // Fetch a large set of listings to compute stats
-  const listings = await searchAirbnb(location, checkin, checkout, 2, undefined, undefined, 100);
+  const listings = await searchAirbnb(location, { checkin, checkout, guests: 2, limit: 100 });
 
   const prices = listings.map(l => l.price_per_night).filter((p): p is number => p !== null && p > 0);
   const ratings = listings.map(l => l.rating).filter((r): r is number => r !== null);
@@ -564,6 +572,23 @@ export async function getMarketStats(
     propertyTypes[t] = (propertyTypes[t] || 0) + 1;
   }
 
+  // Occupancy estimate heuristic (bounded 35-90%)
+  const reviewDensity = listings
+    .map((l) => l.reviews_count)
+    .filter((n): n is number => typeof n === 'number' && n >= 0);
+  const avgReviews = reviewDensity.length > 0
+    ? reviewDensity.reduce((a, b) => a + b, 0) / reviewDensity.length
+    : 0;
+  const ratingFactor = avgRating ? Math.min(1.15, Math.max(0.85, avgRating / 4.6)) : 1;
+  const demandSignal = Math.min(1, avgReviews / 120);
+  const occupancy = Math.round((35 + demandSignal * 45) * ratingFactor);
+  const avgOccupancyEstimate = listings.length > 0 ? Math.min(90, Math.max(35, occupancy)) : null;
+
+  // Monthly revenue potential = ADR * occupancy * 30 nights
+  const monthlyRevenuePotential = avg !== null && avgOccupancyEstimate !== null
+    ? Math.round(avg * (avgOccupancyEstimate / 100) * 30)
+    : null;
+
   return {
     location,
     avg_daily_rate: avg,
@@ -571,6 +596,8 @@ export async function getMarketStats(
     total_listings: listings.length,
     avg_rating: avgRating,
     superhost_pct: superhostPct,
+    avg_occupancy_estimate: avgOccupancyEstimate,
+    monthly_revenue_potential: monthlyRevenuePotential,
     price_distribution: priceDistribution,
     property_types: propertyTypes,
   };

--- a/src/service.ts
+++ b/src/service.ts
@@ -1273,6 +1273,8 @@ serviceRouter.get('/airbnb/search', async (c) => {
         checkin: 'string (optional) — YYYY-MM-DD',
         checkout: 'string (optional) — YYYY-MM-DD',
         guests: 'number (optional, default: 1)',
+        priceMin: 'number (optional) — minimum nightly price',
+        priceMax: 'number (optional) — maximum nightly price',
         limit: 'number (optional, default: 20, max: 50)',
       },
       output: {
@@ -1290,18 +1292,38 @@ serviceRouter.get('/airbnb/search', async (c) => {
   const checkin = c.req.query('checkin') || undefined;
   const checkout = c.req.query('checkout') || undefined;
   const guests = parseInt(c.req.query('guests') || '1') || 1;
+  const priceMinRaw = c.req.query('priceMin');
+  const priceMaxRaw = c.req.query('priceMax');
+  const priceMin = priceMinRaw ? parseInt(priceMinRaw) : undefined;
+  const priceMax = priceMaxRaw ? parseInt(priceMaxRaw) : undefined;
   const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '20') || 20, 1), 50);
 
   try {
     const proxy = getProxy();
     const ip = await getProxyExitIp();
-    const results = await searchAirbnb(location, checkin, checkout, guests, limit);
+    const results = await searchAirbnb(location, { checkin, checkout, guests, priceMin, priceMax, limit });
 
     c.header('X-Payment-Settled', 'true');
     c.header('X-Payment-TxHash', payment.txHash);
 
+    const marketOverview = {
+      avg_daily_rate: results.length > 0
+        ? Math.round(results.filter((r) => r.price_per_night !== null).reduce((a, b) => a + (b.price_per_night || 0), 0) /
+          Math.max(1, results.filter((r) => r.price_per_night !== null).length))
+        : null,
+      median_daily_rate: (() => {
+        const prices = results.map((r) => r.price_per_night).filter((p): p is number => p !== null).sort((a, b) => a - b);
+        return prices.length > 0 ? prices[Math.floor(prices.length / 2)] : null;
+      })(),
+      total_listings: results.length,
+      avg_occupancy_estimate: null as number | null,
+    };
+
     return c.json({
+      location,
+      results,
       listings: results,
+      market_overview: marketOverview,
       meta: { location, checkin, checkout, guests, count: results.length, proxy: { ip, country: proxy.country, type: 'mobile' } },
       payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
     });
@@ -1407,7 +1429,7 @@ serviceRouter.get('/airbnb/market-stats', async (c) => {
         checkout: 'string (optional) — YYYY-MM-DD',
       },
       output: {
-        stats: '{ averageDailyRate, medianPrice, priceDistribution, superhostPercentage, totalListings, averageRating }',
+        stats: '{ avg_daily_rate, median_daily_rate, price_distribution, superhost_pct, total_listings, avg_rating, avg_occupancy_estimate, monthly_revenue_potential }',
       },
     }), 402);
   }

--- a/tests/airbnb-endpoints.test.ts
+++ b/tests/airbnb-endpoints.test.ts
@@ -4,6 +4,7 @@ import app from '../src/index';
 const TEST_WALLET = '0x1111111111111111111111111111111111111111';
 const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_01 = '0x0000000000000000000000000000000000000000000000000000000000002710';
 const USDC_AMOUNT_0_02 = '0x0000000000000000000000000000000000000000000000000000000000004e20';
 const USDC_AMOUNT_0_05 = '0x000000000000000000000000000000000000000000000000000000000000c350';
 
@@ -36,6 +37,40 @@ function airbnbSearchHtml(): string {
       <div>$220 per night</div>
       <div>4.7 (120 reviews)</div>
       <img src="https://a0.muscache.com/im/pictures/sample-2.jpg" />
+    </body></html>
+  `;
+}
+
+function airbnbListingHtml(): string {
+  return `
+    <html><body>
+      <script type="application/ld+json">{"name":"Oceanfront Studio in South Beach","description":"Walk to the beach and enjoy ocean views.","aggregateRating":{"ratingValue":"4.92","reviewCount":"234"}}</script>
+      <div data-testid="listing-type">Entire apartment</div>
+      <div>$189 per night</div>
+      <div>Hosted by Maria</div>
+      <div>1 bedroom · 1 bathroom · 4 guests</div>
+      <div>Superhost</div>
+      <img src="https://a0.muscache.com/im/pictures/sample-1.jpg" />
+      <div>Check-in: 3:00 PM</div>
+      <div>Checkout: 11:00 AM</div>
+    </body></html>
+  `;
+}
+
+function airbnbReviewsHtml(): string {
+  return `
+    <html><body>
+      data-testid="pdp-review"
+      <h3 class="review-author">Alex</h3>
+      <div>January 2026</div>
+      <div>5 out of 5 stars</div>
+      <span data-testid="pdp-review-text">Great stay, very clean and close to the beach.</span>
+      <span>Response from host: Thanks for staying with us!</span>
+      data-testid="pdp-review"
+      <h3 class="review-author">Jordan</h3>
+      <div>December 2025</div>
+      <div>4 out of 5 stars</div>
+      <span data-testid="pdp-review-text">Good location and smooth check-in.</span>
     </body></html>
   `;
 }
@@ -84,6 +119,20 @@ function installFetchMock(usdcAmountHex: string): string[] {
 
     if (url.startsWith('https://www.airbnb.com/s/')) {
       return new Response(airbnbSearchHtml(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    if (url.startsWith('https://www.airbnb.com/rooms/12345678/reviews')) {
+      return new Response(airbnbReviewsHtml(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    if (url.startsWith('https://www.airbnb.com/rooms/12345678')) {
+      return new Response(airbnbListingHtml(), {
         status: 200,
         headers: { 'Content-Type': 'text/html' },
       });
@@ -148,6 +197,68 @@ describe('Airbnb endpoints', () => {
     expect(body.results[0].price_per_night).toBe(189);
     expect(body.market_overview.avg_daily_rate).toBeGreaterThan(0);
     expect(body.payment.txHash).toBe(txHash);
+  });
+
+  test('GET /api/airbnb/listing/:id returns 402 when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/listing/12345678'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.resource).toBe('/api/airbnb/listing/:id');
+  });
+
+  test('GET /api/airbnb/listing/:id returns listing details for paid request', async () => {
+    installFetchMock(USDC_AMOUNT_0_01);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/listing/12345678', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.listing.id).toBe('12345678');
+    expect(body.listing.title).toContain('Oceanfront Studio');
+    expect(body.listing.host.name).toContain('Maria');
+    expect(body.payment.txHash).toBe(txHash);
+  });
+
+  test('GET /api/airbnb/reviews/:listing_id returns 402 when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/reviews/12345678'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.resource).toBe('/api/airbnb/reviews/:listing_id');
+  });
+
+  test('GET /api/airbnb/reviews/:listing_id returns reviews for paid request', async () => {
+    installFetchMock(USDC_AMOUNT_0_01);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/reviews/12345678?limit=2', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(Array.isArray(body.reviews)).toBe(true);
+    expect(body.reviews.length).toBe(2);
+    expect(body.reviews[0].author).toBe('Alex');
+    expect(body.payment.txHash).toBe(txHash);
+  });
+
+  test('GET /api/airbnb/market-stats returns 402 when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/market-stats?location=Miami+Beach'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.resource).toBe('/api/airbnb/market-stats');
   });
 
   test('GET /api/airbnb/market-stats returns computed occupancy + revenue fields', async () => {

--- a/tests/airbnb-endpoints.test.ts
+++ b/tests/airbnb-endpoints.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x1111111111111111111111111111111111111111';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_02 = '0x0000000000000000000000000000000000000000000000000000000000004e20';
+const USDC_AMOUNT_0_05 = '0x000000000000000000000000000000000000000000000000000000000000c350';
+
+let txCounter = 1000;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function airbnbSearchHtml(): string {
+  return `
+    <html><body>
+      data-testid="card-container"
+      <a href="/rooms/12345678">room</a>
+      <div data-testid="listing-card-title">Oceanfront Studio in South Beach</div>
+      <div data-testid="listing-card-subtitle">Entire apartment · 1 bedroom · 1 bathroom · 4 guests</div>
+      <div>$189 per night</div>
+      <div>4.9 (234 reviews)</div>
+      <div>Superhost</div>
+      <img src="https://a0.muscache.com/im/pictures/sample-1.jpg" />
+      data-testid="card-container"
+      <a href="/rooms/87654321">room</a>
+      <div data-testid="listing-card-title">Downtown Loft</div>
+      <div data-testid="listing-card-subtitle">Entire loft · 2 bedrooms · 1 bathroom · 5 guests</div>
+      <div>$220 per night</div>
+      <div>4.7 (120 reviews)</div>
+      <img src="https://a0.muscache.com/im/pictures/sample-2.jpg" />
+    </body></html>
+  `;
+}
+
+function installFetchMock(usdcAmountHex: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(TEST_WALLET),
+            ],
+            data: usdcAmountHex,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://api.ipify.org')) {
+      return new Response(JSON.stringify({ ip: '198.51.100.25' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://www.airbnb.com/s/')) {
+      return new Response(airbnbSearchHtml(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.SOLANA_WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('Airbnb endpoints', () => {
+  test('GET /api/airbnb/search returns 402 when payment is missing', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/search?location=Miami+Beach'));
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/airbnb/search');
+  });
+
+  test('GET /api/airbnb/search returns listings for a valid paid request', async () => {
+    const calls = installFetchMock(USDC_AMOUNT_0_02);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/search?location=Miami+Beach&guests=2&limit=2', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Payment-Settled')).toBe('true');
+    expect(calls.some((url) => url.includes('mainnet.base.org'))).toBe(true);
+    expect(calls.some((url) => url.startsWith('https://www.airbnb.com/s/'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.location).toBe('Miami Beach');
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results[0].id).toBe('12345678');
+    expect(body.results[0].price_per_night).toBe(189);
+    expect(body.market_overview.avg_daily_rate).toBeGreaterThan(0);
+    expect(body.payment.txHash).toBe(txHash);
+  });
+
+  test('GET /api/airbnb/market-stats returns computed occupancy + revenue fields', async () => {
+    installFetchMock(USDC_AMOUNT_0_05);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(new Request('http://localhost/api/airbnb/market-stats?location=Miami+Beach', {
+      headers: {
+        'X-Payment-Signature': txHash,
+        'X-Payment-Network': 'base',
+      },
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.stats.avg_daily_rate).toBeGreaterThan(0);
+    expect(body.stats.avg_occupancy_estimate).toBeGreaterThan(0);
+    expect(body.stats.monthly_revenue_potential).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- harden Airbnb scraping flow with safer search options handling and schema-consistent market stats output
- add support for price range filters and improved response shape for  (, , )
- add occupancy and monthly revenue potential estimates in 
- add endpoint tests for Airbnb x402 flow and market intelligence outputs

## Testing
- bun test v1.3.10 (30e609e0)
<-- GET /api/run?query=plumbers&location=Austin+TX
--> GET /api/run?query=plumbers&location=Austin+TX [33m402[0m 1ms
<-- GET /api/details?placeId=ChIJN1t_tDeuEmsRUsoyG83frY4
--> GET /api/details?placeId=ChIJN1t_tDeuEmsRUsoyG83frY4 [33m402[0m 0ms
<-- GET /api/run?query=plumbers&location=Austin+TX&limit=1
[Scraper] Trying Google Local Search...
[Scraper] Found 0 from Local Search
[Scraper] Trying Google Maps...
[Scraper] Found 0 from Maps
[Scraper] Trying Google Search...
[Scraper] Found 0 from Search
--> GET /api/run?query=plumbers&location=Austin+TX&limit=1 [32m200[0m 2ms
<-- GET /api/details?placeId=place_123
--> GET /api/details?placeId=place_123 [32m200[0m 1ms
<-- GET /api/airbnb/search?location=Miami+Beach
--> GET /api/airbnb/search?location=Miami+Beach [33m402[0m 1ms
<-- GET /api/airbnb/search?location=Miami+Beach&guests=2&limit=2
--> GET /api/airbnb/search?location=Miami+Beach&guests=2&limit=2 [32m200[0m 1ms
<-- GET /api/airbnb/market-stats?location=Miami+Beach
--> GET /api/airbnb/market-stats?location=Miami+Beach [32m200[0m 1ms
- 

Closes #78