### PR TITLE
feat: LinkedIn People & Company Enrichment API (Bounty #77)

### DIFF
--- a/listings/linkedin-enrichment.json
+++ b/listings/linkedin-enrichment.json
@@ -35,6 +35,13 @@
       "price": 0.10,
       "description": "Find employees of a company by title filter",
       "params": ["id", "title?", "limit?"]
+    },
+    {
+      "path": "/api/linkedin/jobs",
+      "method": "GET",
+      "price": 0.10,
+      "description": "Search LinkedIn job postings by keywords, location, and company",
+      "params": ["keywords", "location?", "company?", "limit?"]
     }
   ],
   "wallet": "6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv",

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ app.get('/health', (c) => c.json({
     '/api/linkedin/company',
     '/api/linkedin/search/people',
     '/api/linkedin/company/:id/employees',
+    '/api/linkedin/jobs',
     '/api/reddit/search',
     '/api/reddit/trending',
     '/api/reddit/subreddit/:name',
@@ -114,6 +115,7 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/linkedin/company', description: 'LinkedIn company profile enrichment', price: '0.01 USDC' },
     { method: 'GET', path: '/api/linkedin/search/people', description: 'Search LinkedIn people by keywords', price: '0.01 USDC' },
     { method: 'GET', path: '/api/linkedin/company/:id/employees', description: 'Find company employees by title', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/linkedin/jobs', description: 'Search LinkedIn job postings by keywords, location, company', price: '0.10 USDC' },
     { method: 'GET', path: '/api/reddit/search', description: 'Search Reddit posts by keyword', price: '0.005 USDC' },
     { method: 'GET', path: '/api/reddit/trending', description: 'Get trending Reddit posts', price: '0.005 USDC' },
     { method: 'GET', path: '/api/reddit/subreddit/:name', description: 'Browse subreddit posts', price: '0.005 USDC' },
@@ -162,7 +164,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/audit/:username', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/linkedin/jobs', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/audit/:username', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/scrapers/linkedin-enrichment.ts
+++ b/src/scrapers/linkedin-enrichment.ts
@@ -59,6 +59,18 @@ export interface LinkedInSearchResult {
   profile_url: string;
 }
 
+// Job posting interface
+export interface LinkedInJobPosting {
+  title: string;
+  company: string;
+  location: string;
+  description: string;
+  employment_type?: string;
+  seniority_level?: string;
+  posted_date?: string;
+  job_url: string;
+}
+
 // Extract username from LinkedIn URL
 function extractUsername(url: string): string | null {
   const match = url.match(/linkedin\.com\/in\/([^\/\?]+)/);
@@ -348,6 +360,111 @@ export async function scrapeLinkedInPerson(username: string): Promise<LinkedInPe
 export async function scrapeLinkedInCompany(companyName: string): Promise<LinkedInCompany | null> {
   const url = `https://linkedin.com/company/${companyName}`;
   return fetchLinkedInCompany(url);
+}
+
+// Search LinkedIn job postings using Google
+export async function searchLinkedInJobs(
+  keywords: string,
+  location?: string,
+  companyName?: string,
+  limit: number = 10
+): Promise<LinkedInJobPosting[]> {
+  try {
+    let query = `site:linkedin.com/jobs/view "${keywords}"`;
+    if (location) query += ` "${location}"`;
+    if (companyName) query += ` "${companyName}"`;
+
+    const searchUrl = `https://www.google.com/search?q=${encodeURIComponent(query)}&num=${limit * 2}`;
+
+    const response = await proxyFetch(searchUrl, {
+      headers: {
+        'Accept': 'text/html,application/xhtml+xml',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      timeoutMs: 30_000,
+      maxRetries: 2,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Job search failed: ${response.status}`);
+    }
+
+    const html = await response.text();
+    return parseJobSearchResults(html, limit);
+  } catch (error: any) {
+    console.error('Error searching LinkedIn jobs:', error.message);
+    return [];
+  }
+}
+
+// Parse Google search results for LinkedIn job postings
+function parseJobSearchResults(html: string, limit: number): LinkedInJobPosting[] {
+  const results: LinkedInJobPosting[] = [];
+
+  try {
+    // Match LinkedIn job URLs from Google results
+    const linkRegex = /<a[^>]*href="(https:\/\/[^"]*linkedin\.com\/jobs\/view\/[^"]+)"[^>]*>/gi;
+    const snippetRegex = /<div[^>]*class="[^"]*VwiC3b[^"]*"[^>]*>([\s\S]*?)<\/div>/gi;
+    const titleRegex = /<h3[^>]*>(.*?)<\/h3>/gi;
+
+    const links: string[] = [];
+    let match;
+
+    while ((match = linkRegex.exec(html)) !== null && links.length < limit * 2) {
+      const url = match[1].replace(/&amp;/g, '&');
+      if (!links.includes(url)) links.push(url);
+    }
+
+    const titles: string[] = [];
+    while ((match = titleRegex.exec(html)) !== null && titles.length < limit * 2) {
+      titles.push(
+        match[1]
+          .replace(/<[^>]+>/g, '')
+          .replace(/&#39;/g, "'")
+          .replace(/&quot;/g, '"')
+          .replace(/&amp;/g, '&')
+          .trim()
+      );
+    }
+
+    const snippets: string[] = [];
+    while ((match = snippetRegex.exec(html)) !== null && snippets.length < limit * 2) {
+      snippets.push(
+        match[1]
+          .replace(/<[^>]+>/g, '')
+          .replace(/&#39;/g, "'")
+          .replace(/&quot;/g, '"')
+          .replace(/&amp;/g, '&')
+          .trim()
+      );
+    }
+
+    for (let i = 0; i < Math.min(links.length, limit); i++) {
+      const rawTitle = titles[i] || '';
+      // LinkedIn job titles typically: "Job Title - Company | LinkedIn"
+      const titleParts = rawTitle.split(/\s*[-|]\s*/);
+      const jobTitle = titleParts[0] || 'Unknown Position';
+      const company = titleParts[1] || '';
+
+      const snippet = snippets[i] || '';
+      // Try to extract location from snippet
+      const locMatch = snippet.match(/(?:in\s+|Location:\s*)([A-Z][^.·,]+(?:,\s*[A-Z]{2})?)/);
+      const dateMatch = snippet.match(/(\d+\s+(?:day|week|month|hour)s?\s+ago)/i);
+
+      results.push({
+        title: jobTitle.trim(),
+        company: company.replace(/\s*\|\s*LinkedIn.*$/i, '').trim(),
+        location: locMatch?.[1]?.trim() || '',
+        description: snippet.slice(0, 300),
+        posted_date: dateMatch?.[1] || undefined,
+        job_url: links[i],
+      });
+    }
+  } catch (error) {
+    console.error('Error parsing job search results:', error);
+  }
+
+  return results;
 }
 
 export { searchCompanyEmployees as findCompanyEmployees };

--- a/src/service.ts
+++ b/src/service.ts
@@ -21,11 +21,12 @@ import { scrapeGoogleMaps, extractDetailedBusiness } from './scrapers/maps-scrap
 import { researchRouter } from './routes/research';
 import { trendingRouter } from './routes/trending';
 import { searchAirbnb, getListingDetail, getListingReviews, getMarketStats } from './scrapers/airbnb-scraper';
-import { 
-  scrapeLinkedInPerson, 
-  scrapeLinkedInCompany, 
-  searchLinkedInPeople, 
-  findCompanyEmployees 
+import {
+  scrapeLinkedInPerson,
+  scrapeLinkedInCompany,
+  searchLinkedInPeople,
+  findCompanyEmployees,
+  searchLinkedInJobs
 } from './scrapers/linkedin-enrichment';
 import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile } from './scrapers/instagram-scraper';
 import { searchReddit, getSubreddit, getTrending, getComments } from './scrapers/reddit-scraper';
@@ -794,6 +795,65 @@ serviceRouter.get('/linkedin/company/:id/employees', async (c) => {
     });
   } catch (err: any) {
     return c.json({ error: 'Employee search failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ─── GET /api/linkedin/jobs ────────────────────────
+serviceRouter.get('/linkedin/jobs', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(
+      build402Response('/api/linkedin/jobs', 'LinkedIn Job Posting Search', LINKEDIN_SEARCH_PRICE_USDC, walletAddress, {
+        input: {
+          keywords: 'string — Job title or keywords (required)',
+          location: 'string — Location filter (optional)',
+          company: 'string — Company name filter (optional)',
+          limit: 'number — Max results (default: 10, max: 20)'
+        },
+        output: { jobs: 'LinkedInJobPosting[] — title, company, location, description, posted_date, job_url', meta: 'proxy info' },
+      }),
+      402,
+    );
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, LINKEDIN_SEARCH_PRICE_USDC);
+  if (!verification.valid) {
+    return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+  }
+
+  const keywords = c.req.query('keywords');
+  if (!keywords) {
+    return c.json({ error: 'Missing required parameter: keywords', example: '/api/linkedin/jobs?keywords=software+engineer&location=New+York' }, 400);
+  }
+
+  const location = c.req.query('location') || undefined;
+  const company = c.req.query('company') || undefined;
+  const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '10') || 10, 1), 20);
+
+  try {
+    const proxy = getProxy();
+    const jobs = await searchLinkedInJobs(keywords, location, company, limit);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      jobs,
+      meta: { proxy: { country: proxy.country, type: 'mobile' } },
+      payment: {
+        txHash: payment.txHash,
+        network: payment.network,
+        amount: verification.amount,
+        settled: true,
+      },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'Job search failed', message: err?.message || String(err) }, 502);
   }
 });
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/linkedin/jobs` endpoint for searching LinkedIn job postings by keywords, location, and company name via Google dorking through mobile proxies
- Completes the full LinkedIn enrichment suite with 5 endpoints: person profile, company profile, people search, employee listing, and job posting search
- All endpoints follow x402 payment flow with USDC verification on Solana/Base

## Endpoints

| Endpoint | Price | Description |
|----------|-------|-------------|
| `GET /api/linkedin/person?url=linkedin.com/in/username` | $0.03 | Person profile enrichment |
| `GET /api/linkedin/company?url=linkedin.com/company/name` | $0.05 | Company profile enrichment |
| `GET /api/linkedin/search/people?title=CTO&location=SF` | $0.10 | People search by title/location/industry |
| `GET /api/linkedin/company/:id/employees?title=engineer` | $0.10 | Company employee listing |
| `GET /api/linkedin/jobs?keywords=engineer&location=NYC` | $0.10 | Job posting search |

## Implementation

- Scraper: `src/scrapers/linkedin-enrichment.ts` — public profile parsing via JSON-LD + HTML fallback, Google dorking for search endpoints
- Routes: `src/service.ts` — x402 payment-gated Hono routes with input validation
- Listing: `listings/linkedin-enrichment.json` — marketplace catalog entry
- All requests routed through Proxies.sx mobile (4G/5G) proxies

## Test plan

- [ ] `curl localhost:3000/health` returns 200 with LinkedIn endpoints listed
- [ ] `curl localhost:3000/api/linkedin/person?url=linkedin.com/in/satyanadella` returns 402 with payment schema
- [ ] `curl localhost:3000/api/linkedin/jobs?keywords=engineer` returns 402 with payment schema
- [ ] Person/company enrichment returns structured profile data with valid payment
- [ ] Job search returns postings with title, company, location, description

Closes #77