### PR TITLE
feat: App Store Intelligence API (Bounty #54)

### DIFF
--- a/listings/appstore-intelligence.json
+++ b/listings/appstore-intelligence.json
@@ -1,0 +1,102 @@
+{
+  "id": "appstore-intelligence",
+  "name": "App Store Intelligence API",
+  "description": "Real-time app rankings, reviews, metadata, and trends from Apple App Store and Google Play Store via real 4G/5G mobile carrier IPs. Search, compare, and track apps across 6 countries.",
+  "longDescription": "Enterprise-grade app store intelligence at pay-per-request pricing. Five endpoints: category rankings (top 200), app detail with reviews and sentiment analysis, keyword search, trending app discovery, and side-by-side competitor comparison. Supports Apple App Store and Google Play Store across US, DE, FR, ES, GB, and PL. Mobile carrier IPs are mandatory — Google Play bans datacenter IPs, and Apple geo-fences rankings by country and carrier. Replaces $30K-$100K/year tools like Sensor Tower and data.ai with x402 micropayments at $0.01-0.03/query.",
+  "endpoint": "https://marketplace-api-9kvb.onrender.com/api/appstore",
+  "docsUrl": "https://github.com/CelebrityPunks/marketplace-service-template/blob/feat/appstore-intelligence/README.md",
+  "pricing": {
+    "model": "per-request",
+    "endpoints": [
+      { "path": "/api/appstore/rankings", "price": "$0.01", "unit": "per request" },
+      { "path": "/api/appstore/app", "price": "$0.02", "unit": "per request" },
+      { "path": "/api/appstore/search", "price": "$0.01", "unit": "per request" },
+      { "path": "/api/appstore/trending", "price": "$0.01", "unit": "per request" },
+      { "path": "/api/appstore/compare", "price": "$0.03", "unit": "per request" }
+    ],
+    "comparison": "Sensor Tower: $30K-$100K+/year. data.ai: $50K+/year. SimilarWeb: $20K+/year. AppFollow: $120/month. Our mobile proxy approach delivers the same real-time data at $0.01-0.03/query with zero contracts or signup.",
+    "currency": "USDC",
+    "networks": [
+      {
+        "network": "solana",
+        "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "recipient": "6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv",
+        "asset": "USDC",
+        "assetAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+      },
+      {
+        "network": "base",
+        "chainId": "eip155:8453",
+        "recipient": "0xF8cD900794245fc36CBE65be9afc23CDF5103042",
+        "asset": "USDC",
+        "assetAddress": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      }
+    ]
+  },
+  "whyMobileProxy": "Google Play Store bans datacenter IPs after ~500-1000 app lookups per day. Apple App Store geo-fences rankings by country AND carrier — a T-Mobile IP in the US sees different featured apps than Vodafone in Germany. Mobile carrier IPs (4G/5G) appear as legitimate app store users, bypassing all IP reputation checks, rate limits, and geo-restrictions. Reviews are sorted and displayed differently based on user location and device type.",
+  "outputSchema": {
+    "rankings": {
+      "type": "rankings",
+      "store": "apple | google",
+      "category": "string",
+      "country": "string",
+      "rankings": [{
+        "rank": "number",
+        "appName": "string",
+        "developer": "string",
+        "appId": "string",
+        "rating": "number | null",
+        "ratingCount": "number | null",
+        "price": "string",
+        "inAppPurchases": "boolean",
+        "category": "string",
+        "lastUpdated": "string | null",
+        "size": "string | null",
+        "icon": "string | null"
+      }],
+      "metadata": { "totalRanked": "number", "scrapedAt": "string" },
+      "proxy": { "country": "string", "type": "mobile" },
+      "payment": { "txHash": "string", "network": "string", "amount": "number", "settled": "boolean" }
+    },
+    "app": {
+      "type": "app",
+      "app": {
+        "appName": "string",
+        "developer": "string",
+        "appId": "string",
+        "description": "string",
+        "rating": "number | null",
+        "ratingCount": "number | null",
+        "price": "string",
+        "inAppPurchases": "boolean",
+        "reviews": "[{ author, rating, title, text, date, helpful }]"
+      },
+      "reviewSentiment": "{ overall, positive%, neutral%, negative% }"
+    }
+  },
+  "limitations": [
+    "Max 200 apps per rankings request",
+    "Max 50 results per search request",
+    "Max 5 apps per comparison request",
+    "Reviews limited to 10 most recent per app detail request",
+    "Supported countries: US, DE, FR, ES, GB, PL",
+    "Rate limited to 60 requests/minute per client IP"
+  ],
+  "category": "scraper",
+  "tags": [
+    "app-store", "google-play", "apple", "rankings", "reviews",
+    "sentiment-analysis", "competitor-intelligence", "mobile-apps",
+    "market-research", "trending", "scraper"
+  ],
+  "owner": {
+    "name": "CelebrityPunks",
+    "github": "CelebrityPunks"
+  },
+  "status": "pending",
+  "featured": false,
+  "addedAt": "2026-03-14",
+  "x402": {
+    "discoveryUrl": "https://marketplace-api-9kvb.onrender.com/api/appstore/rankings",
+    "wellKnown": "https://marketplace-api-9kvb.onrender.com/.well-known/x402.json"
+  }
+}

--- a/listings/index.json
+++ b/listings/index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "updatedAt": "2026-02-15",
-  "count": 6,
+  "count": 7,
   "services": [
     {
       "id": "proxies-sx-mobile",
@@ -174,6 +174,36 @@
       "status": "active",
       "featured": false,
       "detailsFile": "prediction-market-aggregator.json"
+    },
+    {
+      "id": "appstore-intelligence",
+      "name": "App Store Intelligence API",
+      "description": "Real-time app rankings, reviews, and metadata from Apple App Store and Google Play Store via 4G/5G mobile proxies. $0.01-0.03/query via x402.",
+      "endpoint": "https://marketplace-api-9kvb.onrender.com/api/appstore",
+      "docsUrl": "https://github.com/CelebrityPunks/marketplace-service-template/blob/feat/appstore-intelligence/README.md",
+      "pricing": {
+        "model": "per-request",
+        "amount": "0.01",
+        "minimum": "0.01",
+        "currency": "USDC"
+      },
+      "category": "scraper",
+      "tags": [
+        "app-store",
+        "google-play",
+        "apple",
+        "rankings",
+        "reviews",
+        "competitor-intelligence",
+        "market-research"
+      ],
+      "owner": {
+        "name": "CelebrityPunks",
+        "github": "CelebrityPunks"
+      },
+      "status": "pending",
+      "featured": false,
+      "detailsFile": "appstore-intelligence.json"
     }
   ],
   "networks": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,11 @@ app.get('/health', (c) => c.json({
     '/api/airbnb/market-stats',
     '/api/research',
     '/api/trending',
+    '/api/appstore/rankings',
+    '/api/appstore/app',
+    '/api/appstore/search',
+    '/api/appstore/trending',
+    '/api/appstore/compare',
   ],
 }));
 
@@ -129,6 +134,11 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/airbnb/market-stats', description: 'Airbnb market statistics', price: '0.05 USDC' },
     { method: 'GET', path: '/api/research', description: 'Multi-source research aggregation', price: '0.05 USDC' },
     { method: 'GET', path: '/api/trending', description: 'Trending topics intelligence', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/appstore/rankings', description: 'App Store rankings by category and country (Apple + Google Play)', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/appstore/app', description: 'App details + reviews + sentiment analysis', price: '0.02 USDC' },
+    { method: 'GET', path: '/api/appstore/search', description: 'Search apps by keyword across app stores', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/appstore/trending', description: 'Trending and new apps discovery', price: '0.01 USDC' },
+    { method: 'GET', path: '/api/appstore/compare', description: 'Side-by-side app comparison with sentiment', price: '0.03 USDC' },
   ],
   pricing: {
     amount: process.env.PRICE_USDC || '0.005',
@@ -162,7 +172,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/audit/:username', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/audit/:username', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending', '/api/appstore/rankings', '/api/appstore/app', '/api/appstore/search', '/api/appstore/trending', '/api/appstore/compare'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/routes/appstore.ts
+++ b/src/routes/appstore.ts
@@ -1,0 +1,574 @@
+/**
+ * App Store Intelligence Routes
+ * ─────────────────────────────
+ * GET /api/appstore/rankings   — Top app rankings by category + country
+ * GET /api/appstore/app        — App details + reviews
+ * GET /api/appstore/search     — Search apps by keyword
+ * GET /api/appstore/trending   — Trending/new apps
+ * GET /api/appstore/compare    — Compare apps side by side
+ *
+ * Supports Apple App Store + Google Play Store.
+ * All requests routed through real 4G/5G mobile carrier IPs.
+ *
+ * Pricing: $0.01 USDC per request (rankings, search, trending)
+ *          $0.02 USDC per request (app detail with reviews)
+ *          $0.03 USDC per request (compare — multi-app)
+ */
+
+import { Hono } from 'hono';
+import { extractPayment, verifyPayment, build402Response } from '../payment';
+import { getProxy, proxyFetch } from '../proxy';
+import { aggregateSentiment } from '../analysis/sentiment';
+import {
+  getRankings,
+  getAppDetail,
+  searchApps,
+  getTrendingApps,
+} from '../scrapers/appstore-scraper';
+import type { AppRanking, AppDetail, AppSearchResult, TrendingApp } from '../scrapers/appstore-scraper';
+
+export const appstoreRouter = new Hono();
+
+// ─── CONSTANTS ──────────────────────────────────────
+
+const WALLET_ADDRESS = process.env.WALLET_ADDRESS ?? '';
+
+const PRICE_RANKINGS = 0.01;
+const PRICE_APP_DETAIL = 0.02;
+const PRICE_SEARCH = 0.01;
+const PRICE_TRENDING = 0.01;
+const PRICE_COMPARE = 0.03;
+
+const SUPPORTED_STORES = ['apple', 'google'] as const;
+type Store = typeof SUPPORTED_STORES[number];
+
+const SUPPORTED_COUNTRIES = ['US', 'DE', 'FR', 'ES', 'GB', 'PL'];
+
+const VALID_CATEGORIES = [
+  'all', 'games', 'business', 'education', 'entertainment', 'finance',
+  'food-drink', 'health-fitness', 'lifestyle', 'medical', 'music',
+  'navigation', 'news', 'photo-video', 'productivity', 'reference',
+  'shopping', 'social', 'sports', 'travel', 'utilities', 'weather',
+];
+
+const DESCRIPTION_RANKINGS = 'App Store Rankings Intelligence — top app charts by category and country from Apple App Store and Google Play Store via real 4G/5G mobile carrier IPs.';
+const DESCRIPTION_APP = 'App Store App Intelligence — detailed app metadata, reviews, ratings, and changelog from Apple App Store and Google Play Store.';
+const DESCRIPTION_SEARCH = 'App Store Search Intelligence — search apps by keyword across Apple App Store and Google Play Store.';
+const DESCRIPTION_TRENDING = 'App Store Trending Intelligence — discover trending and new apps on Apple App Store and Google Play Store.';
+const DESCRIPTION_COMPARE = 'App Store Compare Intelligence — side-by-side comparison of multiple apps with review sentiment analysis.';
+
+const OUTPUT_SCHEMA_RANKINGS = {
+  input: {
+    store: '"apple" | "google" (required)',
+    category: 'string — app category (default: "all")',
+    country: '"US" | "DE" | "FR" | "ES" | "GB" | "PL" (default: "US")',
+    limit: 'number — max results 1-200 (default: 50)',
+  },
+  output: {
+    type: '"rankings"',
+    store: '"apple" | "google"',
+    category: 'string',
+    country: 'string',
+    rankings: [{
+      rank: 'number',
+      appName: 'string',
+      developer: 'string',
+      appId: 'string',
+      rating: 'number | null',
+      ratingCount: 'number | null',
+      price: 'string',
+      inAppPurchases: 'boolean',
+      category: 'string',
+      lastUpdated: 'string | null',
+      size: 'string | null',
+      icon: 'string | null',
+    }],
+    metadata: '{ totalRanked, scrapedAt }',
+    proxy: '{ country, type }',
+    payment: '{ txHash, network, amount, settled }',
+  },
+};
+
+const OUTPUT_SCHEMA_APP = {
+  input: {
+    store: '"apple" | "google" (required)',
+    appId: 'string — app identifier (required)',
+    country: '"US" | "DE" | "FR" | "ES" | "GB" | "PL" (default: "US")',
+  },
+  output: {
+    type: '"app"',
+    store: 'string',
+    app: '{appName, developer, appId, description, rating, ratingCount, price, inAppPurchases, category, lastUpdated, size, icon, screenshots, version, whatsNew, contentRating, installs, reviews}',
+    reviewSentiment: '{ overall, positive%, neutral%, negative% }',
+    proxy: '{ country, type }',
+    payment: '{ txHash, network, amount, settled }',
+  },
+};
+
+const OUTPUT_SCHEMA_SEARCH = {
+  input: {
+    store: '"apple" | "google" (required)',
+    query: 'string — search keyword (required)',
+    country: '"US" | "DE" | "FR" | "ES" | "GB" | "PL" (default: "US")',
+    limit: 'number — max results 1-50 (default: 25)',
+  },
+  output: {
+    type: '"search"',
+    store: 'string',
+    query: 'string',
+    results: '[{appName, developer, appId, rating, ratingCount, price, icon, description, category}]',
+    proxy: '{ country, type }',
+    payment: '{ txHash, network, amount, settled }',
+  },
+};
+
+const OUTPUT_SCHEMA_TRENDING = {
+  input: {
+    store: '"apple" | "google" (required)',
+    country: '"US" | "DE" | "FR" | "ES" | "GB" | "PL" (default: "US")',
+    limit: 'number — max results 1-100 (default: 25)',
+  },
+  output: {
+    type: '"trending"',
+    store: 'string',
+    trending: '[{rank, appName, developer, appId, rating, ratingCount, price, icon, category, growthSignal}]',
+    proxy: '{ country, type }',
+    payment: '{ txHash, network, amount, settled }',
+  },
+};
+
+// ─── HELPERS ────────────────────────────────────────
+
+function validateStore(store: string | undefined): Store | null {
+  if (!store) return null;
+  const lower = store.toLowerCase() as Store;
+  return SUPPORTED_STORES.includes(lower) ? lower : null;
+}
+
+function validateCategory(category: string | undefined): string {
+  if (!category) return 'all';
+  const lower = category.toLowerCase();
+  return VALID_CATEGORIES.includes(lower) ? lower : 'all';
+}
+
+function validateCountry(country: string | undefined): string {
+  if (!country) return 'US';
+  const upper = country.toUpperCase();
+  return SUPPORTED_COUNTRIES.includes(upper) ? upper : 'US';
+}
+
+function safeInt(val: string | undefined, fallback: number, min: number, max: number): number {
+  if (!val) return fallback;
+  const n = parseInt(val);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+async function getProxyExitIp(): Promise<string | null> {
+  try {
+    const r = await proxyFetch('https://api.ipify.org?format=json', {
+      headers: { Accept: 'application/json' },
+      maxRetries: 1,
+      timeoutMs: 5_000,
+    });
+    if (!r.ok) return null;
+    const data = await r.json() as { ip?: string };
+    return typeof data?.ip === 'string' ? data.ip.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── RANKINGS ENDPOINT ──────────────────────────────
+
+appstoreRouter.get('/rankings', async (c) => {
+  if (!WALLET_ADDRESS) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(
+      build402Response('/api/appstore/rankings', DESCRIPTION_RANKINGS, PRICE_RANKINGS, WALLET_ADDRESS, OUTPUT_SCHEMA_RANKINGS),
+      402,
+    );
+  }
+
+  const store = validateStore(c.req.query('store'));
+  if (!store) {
+    return c.json({ error: 'Missing or invalid "store" parameter. Use "apple" or "google".' }, 400);
+  }
+
+  const category = validateCategory(c.req.query('category'));
+  const country = validateCountry(c.req.query('country'));
+  const limit = safeInt(c.req.query('limit'), 50, 1, 200);
+
+  const verification = await verifyPayment(payment, WALLET_ADDRESS, PRICE_RANKINGS);
+  if (!verification.valid) {
+    return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+  }
+
+  const proxyConfig = getProxy();
+
+  try {
+    const rankings = await getRankings(store, category, country, limit);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash.slice(0, 256));
+
+    return c.json({
+      type: 'rankings',
+      store,
+      category,
+      country,
+      timestamp: new Date().toISOString(),
+      rankings,
+      metadata: {
+        totalRanked: rankings.length,
+        scrapedAt: new Date().toISOString(),
+      },
+      proxy: {
+        country: proxyConfig.country,
+        type: 'mobile',
+      },
+      payment: {
+        txHash: payment.txHash,
+        network: payment.network,
+        amount: verification.amount ?? PRICE_RANKINGS,
+        settled: true,
+      },
+    });
+  } catch (err: any) {
+    console.error('[appstore] Rankings error:', err.message);
+    return c.json({ error: 'Failed to fetch rankings', detail: err.message }, 502);
+  }
+});
+
+// ─── APP DETAIL ENDPOINT ────────────────────────────
+
+appstoreRouter.get('/app', async (c) => {
+  if (!WALLET_ADDRESS) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(
+      build402Response('/api/appstore/app', DESCRIPTION_APP, PRICE_APP_DETAIL, WALLET_ADDRESS, OUTPUT_SCHEMA_APP),
+      402,
+    );
+  }
+
+  const store = validateStore(c.req.query('store'));
+  if (!store) {
+    return c.json({ error: 'Missing or invalid "store" parameter. Use "apple" or "google".' }, 400);
+  }
+
+  const appId = c.req.query('appId');
+  if (!appId || appId.length < 1 || appId.length > 200) {
+    return c.json({ error: 'Missing or invalid "appId" parameter.' }, 400);
+  }
+
+  const country = validateCountry(c.req.query('country'));
+
+  const verification = await verifyPayment(payment, WALLET_ADDRESS, PRICE_APP_DETAIL);
+  if (!verification.valid) {
+    return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+  }
+
+  const proxyConfig = getProxy();
+
+  try {
+    const app = await getAppDetail(store, appId, country);
+
+    // Compute review sentiment
+    const reviewTexts = app.reviews
+      .filter(r => r.text.length > 5)
+      .map(r => `${r.title || ''} ${r.text}`);
+    const sentiment = aggregateSentiment(reviewTexts);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash.slice(0, 256));
+
+    return c.json({
+      type: 'app',
+      store,
+      country,
+      timestamp: new Date().toISOString(),
+      app,
+      reviewSentiment: sentiment,
+      proxy: {
+        country: proxyConfig.country,
+        type: 'mobile',
+      },
+      payment: {
+        txHash: payment.txHash,
+        network: payment.network,
+        amount: verification.amount ?? PRICE_APP_DETAIL,
+        settled: true,
+      },
+    });
+  } catch (err: any) {
+    console.error('[appstore] App detail error:', err.message);
+    return c.json({ error: 'Failed to fetch app details', detail: err.message }, 502);
+  }
+});
+
+// ─── SEARCH ENDPOINT ────────────────────────────────
+
+appstoreRouter.get('/search', async (c) => {
+  if (!WALLET_ADDRESS) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(
+      build402Response('/api/appstore/search', DESCRIPTION_SEARCH, PRICE_SEARCH, WALLET_ADDRESS, OUTPUT_SCHEMA_SEARCH),
+      402,
+    );
+  }
+
+  const store = validateStore(c.req.query('store'));
+  if (!store) {
+    return c.json({ error: 'Missing or invalid "store" parameter. Use "apple" or "google".' }, 400);
+  }
+
+  const query = c.req.query('query')?.trim();
+  if (!query || query.length < 1 || query.length > 200) {
+    return c.json({ error: 'Missing or invalid "query" parameter.' }, 400);
+  }
+
+  const country = validateCountry(c.req.query('country'));
+  const limit = safeInt(c.req.query('limit'), 25, 1, 50);
+
+  const verification = await verifyPayment(payment, WALLET_ADDRESS, PRICE_SEARCH);
+  if (!verification.valid) {
+    return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+  }
+
+  const proxyConfig = getProxy();
+
+  try {
+    const results = await searchApps(store, query, country, limit);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash.slice(0, 256));
+
+    return c.json({
+      type: 'search',
+      store,
+      query,
+      country,
+      timestamp: new Date().toISOString(),
+      results,
+      metadata: {
+        totalResults: results.length,
+        scrapedAt: new Date().toISOString(),
+      },
+      proxy: {
+        country: proxyConfig.country,
+        type: 'mobile',
+      },
+      payment: {
+        txHash: payment.txHash,
+        network: payment.network,
+        amount: verification.amount ?? PRICE_SEARCH,
+        settled: true,
+      },
+    });
+  } catch (err: any) {
+    console.error('[appstore] Search error:', err.message);
+    return c.json({ error: 'Failed to search apps', detail: err.message }, 502);
+  }
+});
+
+// ─── TRENDING ENDPOINT ──────────────────────────────
+
+appstoreRouter.get('/trending', async (c) => {
+  if (!WALLET_ADDRESS) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(
+      build402Response('/api/appstore/trending', DESCRIPTION_TRENDING, PRICE_TRENDING, WALLET_ADDRESS, OUTPUT_SCHEMA_TRENDING),
+      402,
+    );
+  }
+
+  const store = validateStore(c.req.query('store'));
+  if (!store) {
+    return c.json({ error: 'Missing or invalid "store" parameter. Use "apple" or "google".' }, 400);
+  }
+
+  const country = validateCountry(c.req.query('country'));
+  const limit = safeInt(c.req.query('limit'), 25, 1, 100);
+
+  const verification = await verifyPayment(payment, WALLET_ADDRESS, PRICE_TRENDING);
+  if (!verification.valid) {
+    return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+  }
+
+  const proxyConfig = getProxy();
+
+  try {
+    const trending = await getTrendingApps(store, country, limit);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash.slice(0, 256));
+
+    return c.json({
+      type: 'trending',
+      store,
+      country,
+      timestamp: new Date().toISOString(),
+      trending,
+      metadata: {
+        totalResults: trending.length,
+        scrapedAt: new Date().toISOString(),
+      },
+      proxy: {
+        country: proxyConfig.country,
+        type: 'mobile',
+      },
+      payment: {
+        txHash: payment.txHash,
+        network: payment.network,
+        amount: verification.amount ?? PRICE_TRENDING,
+        settled: true,
+      },
+    });
+  } catch (err: any) {
+    console.error('[appstore] Trending error:', err.message);
+    return c.json({ error: 'Failed to fetch trending apps', detail: err.message }, 502);
+  }
+});
+
+// ─── COMPARE ENDPOINT ───────────────────────────────
+
+appstoreRouter.get('/compare', async (c) => {
+  if (!WALLET_ADDRESS) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(
+      build402Response('/api/appstore/compare', DESCRIPTION_COMPARE, PRICE_COMPARE, WALLET_ADDRESS, {
+        input: {
+          store: '"apple" | "google" (required)',
+          appIds: 'string — comma-separated app IDs (2-5 apps, required)',
+          country: '"US" | "DE" | "FR" | "ES" | "GB" | "PL" (default: "US")',
+        },
+        output: {
+          type: '"compare"',
+          apps: '[AppDetail with reviewSentiment]',
+          comparison: '{ highestRated, mostReviewed, bestSentiment, summary }',
+        },
+      }),
+      402,
+    );
+  }
+
+  const store = validateStore(c.req.query('store'));
+  if (!store) {
+    return c.json({ error: 'Missing or invalid "store" parameter. Use "apple" or "google".' }, 400);
+  }
+
+  const appIdsRaw = c.req.query('appIds')?.trim();
+  if (!appIdsRaw) {
+    return c.json({ error: 'Missing "appIds" parameter. Provide 2-5 comma-separated app IDs.' }, 400);
+  }
+
+  const appIds = appIdsRaw.split(',').map(id => id.trim()).filter(id => id.length > 0);
+  if (appIds.length < 2 || appIds.length > 5) {
+    return c.json({ error: 'Provide 2-5 app IDs separated by commas.' }, 400);
+  }
+
+  const country = validateCountry(c.req.query('country'));
+
+  const verification = await verifyPayment(payment, WALLET_ADDRESS, PRICE_COMPARE);
+  if (!verification.valid) {
+    return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+  }
+
+  const proxyConfig = getProxy();
+
+  try {
+    const appResults = await Promise.allSettled(
+      appIds.map(id => getAppDetail(store, id, country))
+    );
+
+    const apps: Array<AppDetail & { reviewSentiment: any }> = [];
+    const errors: string[] = [];
+
+    for (let i = 0; i < appResults.length; i++) {
+      const result = appResults[i];
+      if (result.status === 'fulfilled') {
+        const app = result.value;
+        const reviewTexts = app.reviews
+          .filter(r => r.text.length > 5)
+          .map(r => `${r.title || ''} ${r.text}`);
+        const sentiment = aggregateSentiment(reviewTexts);
+        apps.push({ ...app, reviewSentiment: sentiment });
+      } else {
+        errors.push(`${appIds[i]}: ${result.reason?.message || 'fetch failed'}`);
+      }
+    }
+
+    if (apps.length < 2) {
+      return c.json({
+        error: 'Could not fetch enough apps for comparison',
+        details: errors,
+      }, 502);
+    }
+
+    // Build comparison summary
+    const withRating = apps.filter(a => a.rating !== null);
+    const highestRated = withRating.length > 0
+      ? withRating.reduce((best, app) => (app.rating! > (best.rating || 0)) ? app : best)
+      : null;
+
+    const withReviews = apps.filter(a => a.ratingCount !== null);
+    const mostReviewed = withReviews.length > 0
+      ? withReviews.reduce((best, app) => (app.ratingCount! > (best.ratingCount || 0)) ? app : best)
+      : null;
+
+    const bestSentiment = apps.reduce((best, app) => {
+      return (app.reviewSentiment.positive > best.reviewSentiment.positive) ? app : best;
+    });
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash.slice(0, 256));
+
+    return c.json({
+      type: 'compare',
+      store,
+      country,
+      timestamp: new Date().toISOString(),
+      apps,
+      comparison: {
+        highestRated: highestRated ? { appName: highestRated.appName, appId: highestRated.appId, rating: highestRated.rating } : null,
+        mostReviewed: mostReviewed ? { appName: mostReviewed.appName, appId: mostReviewed.appId, ratingCount: mostReviewed.ratingCount } : null,
+        bestSentiment: { appName: bestSentiment.appName, appId: bestSentiment.appId, sentiment: bestSentiment.reviewSentiment },
+        appsCompared: apps.length,
+      },
+      ...(errors.length > 0 ? { warnings: errors } : {}),
+      proxy: {
+        country: proxyConfig.country,
+        type: 'mobile',
+      },
+      payment: {
+        txHash: payment.txHash,
+        network: payment.network,
+        amount: verification.amount ?? PRICE_COMPARE,
+        settled: true,
+      },
+    });
+  } catch (err: any) {
+    console.error('[appstore] Compare error:', err.message);
+    return c.json({ error: 'Failed to compare apps', detail: err.message }, 502);
+  }
+});

--- a/src/scrapers/appstore-scraper.ts
+++ b/src/scrapers/appstore-scraper.ts
@@ -1,0 +1,1047 @@
+/**
+ * App Store Intelligence Scraper
+ * ──────────────────────────────
+ * Scrapes Apple App Store and Google Play Store through real 4G/5G
+ * mobile carrier IPs for authentic app rankings, reviews, metadata,
+ * and trending data.
+ *
+ * Mobile proxies are mandatory because:
+ * - Google Play bans datacenter IPs after ~500-1K requests/day
+ * - Apple geo-fences rankings by country + carrier
+ * - Review ordering differs by location/device type
+ */
+
+import { proxyFetch } from '../proxy';
+
+// ─── TYPES ──────────────────────────────────────────
+
+export interface AppRanking {
+  rank: number;
+  appName: string;
+  developer: string;
+  appId: string;
+  rating: number | null;
+  ratingCount: number | null;
+  price: string;
+  inAppPurchases: boolean;
+  category: string;
+  lastUpdated: string | null;
+  size: string | null;
+  icon: string | null;
+}
+
+export interface AppDetail {
+  appName: string;
+  developer: string;
+  appId: string;
+  description: string;
+  rating: number | null;
+  ratingCount: number | null;
+  price: string;
+  inAppPurchases: boolean;
+  category: string;
+  lastUpdated: string | null;
+  size: string | null;
+  icon: string | null;
+  screenshots: string[];
+  version: string | null;
+  whatsNew: string | null;
+  contentRating: string | null;
+  installs: string | null;
+  reviews: AppReview[];
+}
+
+export interface AppReview {
+  author: string;
+  rating: number;
+  title: string | null;
+  text: string;
+  date: string | null;
+  helpful: number;
+}
+
+export interface AppSearchResult {
+  appName: string;
+  developer: string;
+  appId: string;
+  rating: number | null;
+  ratingCount: number | null;
+  price: string;
+  icon: string | null;
+  description: string;
+  category: string | null;
+}
+
+export interface TrendingApp {
+  rank: number;
+  appName: string;
+  developer: string;
+  appId: string;
+  rating: number | null;
+  ratingCount: number | null;
+  price: string;
+  icon: string | null;
+  category: string | null;
+  growthSignal: string | null;
+}
+
+// ─── CONSTANTS ──────────────────────────────────────
+
+const SUPPORTED_COUNTRIES = ['US', 'DE', 'FR', 'ES', 'GB', 'PL'];
+
+const APPLE_COUNTRY_MAP: Record<string, string> = {
+  US: 'us', DE: 'de', FR: 'fr', ES: 'es', GB: 'gb', PL: 'pl',
+};
+
+const GOOGLE_COUNTRY_MAP: Record<string, string> = {
+  US: 'us', DE: 'de', FR: 'fr', ES: 'es', GB: 'gb', PL: 'pl',
+};
+
+const GOOGLE_LANG_MAP: Record<string, string> = {
+  US: 'en', DE: 'de', FR: 'fr', ES: 'es', GB: 'en', PL: 'pl',
+};
+
+const APPLE_CATEGORY_MAP: Record<string, number> = {
+  'all': 36,
+  'games': 6014,
+  'business': 6000,
+  'education': 6017,
+  'entertainment': 6016,
+  'finance': 6015,
+  'food-drink': 6023,
+  'health-fitness': 6013,
+  'lifestyle': 6012,
+  'medical': 6020,
+  'music': 6011,
+  'navigation': 6010,
+  'news': 6009,
+  'photo-video': 6008,
+  'productivity': 6007,
+  'reference': 6006,
+  'shopping': 6024,
+  'social': 6005,
+  'sports': 6004,
+  'travel': 6003,
+  'utilities': 6002,
+  'weather': 6001,
+};
+
+const GOOGLE_CATEGORY_MAP: Record<string, string> = {
+  'all': '',
+  'games': 'GAME',
+  'business': 'BUSINESS',
+  'education': 'EDUCATION',
+  'entertainment': 'ENTERTAINMENT',
+  'finance': 'FINANCE',
+  'food-drink': 'FOOD_AND_DRINK',
+  'health-fitness': 'HEALTH_AND_FITNESS',
+  'lifestyle': 'LIFESTYLE',
+  'medical': 'MEDICAL',
+  'music': 'MUSIC_AND_AUDIO',
+  'navigation': 'MAPS_AND_NAVIGATION',
+  'news': 'NEWS_AND_MAGAZINES',
+  'photo-video': 'PHOTOGRAPHY',
+  'productivity': 'PRODUCTIVITY',
+  'reference': 'BOOKS_AND_REFERENCE',
+  'shopping': 'SHOPPING',
+  'social': 'SOCIAL',
+  'sports': 'SPORTS',
+  'travel': 'TRAVEL_AND_LOCAL',
+  'utilities': 'TOOLS',
+  'weather': 'WEATHER',
+};
+
+const MOBILE_USER_AGENTS = [
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.90 Mobile Safari/537.36',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/122.0.6261.89 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (Linux; Android 14; SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.90 Mobile Safari/537.36',
+];
+
+function getRandomUA(): string {
+  return MOBILE_USER_AGENTS[Math.floor(Math.random() * MOBILE_USER_AGENTS.length)];
+}
+
+function validateCountry(country: string): string {
+  const upper = country.toUpperCase();
+  if (SUPPORTED_COUNTRIES.includes(upper)) return upper;
+  return 'US';
+}
+
+// ─── HTML PARSING HELPERS ───────────────────────────
+
+function decodeEntities(str: string): string {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code)))
+    .replace(/&nbsp;/g, ' ');
+}
+
+function extractBetween(html: string, startMarker: string, endMarker: string): string | null {
+  const startIdx = html.indexOf(startMarker);
+  if (startIdx === -1) return null;
+  const afterStart = startIdx + startMarker.length;
+  const endIdx = html.indexOf(endMarker, afterStart);
+  if (endIdx === -1) return null;
+  return html.slice(afterStart, endIdx);
+}
+
+function extractAllBetween(html: string, startMarker: string, endMarker: string): string[] {
+  const results: string[] = [];
+  let searchFrom = 0;
+  while (searchFrom < html.length) {
+    const startIdx = html.indexOf(startMarker, searchFrom);
+    if (startIdx === -1) break;
+    const afterStart = startIdx + startMarker.length;
+    const endIdx = html.indexOf(endMarker, afterStart);
+    if (endIdx === -1) break;
+    results.push(html.slice(afterStart, endIdx));
+    searchFrom = endIdx + endMarker.length;
+  }
+  return results;
+}
+
+function extractText(html: string): string {
+  return decodeEntities(
+    html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+  );
+}
+
+// ─── APPLE APP STORE ────────────────────────────────
+
+async function appleFetch(url: string): Promise<string> {
+  const response = await proxyFetch(url, {
+    headers: {
+      'User-Agent': getRandomUA(),
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Cache-Control': 'no-cache',
+    },
+    maxRetries: 2,
+    timeoutMs: 25_000,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Apple App Store returned ${response.status}`);
+  }
+
+  return response.text();
+}
+
+async function appleApiFetch(url: string): Promise<any> {
+  const response = await proxyFetch(url, {
+    headers: {
+      'User-Agent': getRandomUA(),
+      'Accept': 'application/json',
+      'Accept-Language': 'en-US,en;q=0.9',
+    },
+    maxRetries: 2,
+    timeoutMs: 25_000,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Apple API returned ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch top app rankings from Apple App Store using iTunes RSS feed.
+ */
+export async function getAppleRankings(
+  category: string = 'all',
+  country: string = 'US',
+  limit: number = 50,
+): Promise<AppRanking[]> {
+  country = validateCountry(country);
+  const cc = APPLE_COUNTRY_MAP[country] || 'us';
+  const genreId = APPLE_CATEGORY_MAP[category.toLowerCase()] || APPLE_CATEGORY_MAP['all'];
+  const safeLimit = Math.min(Math.max(limit, 1), 200);
+
+  // Use iTunes RSS JSON feed for rankings
+  const url = `https://rss.applemarketingtools.com/api/v2/${cc}/apps/top-free/${safeLimit}/apps.json`;
+
+  const data = await appleApiFetch(url);
+  const results: AppRanking[] = [];
+
+  const entries = data?.feed?.results || [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const genres = entry.genres || [];
+    const primaryGenre = genres[0]?.name || category;
+
+    // If filtering by category, check genre match
+    if (category.toLowerCase() !== 'all') {
+      const categoryName = category.replace(/-/g, ' ').toLowerCase();
+      const matchesCategory = genres.some((g: any) =>
+        g.name?.toLowerCase().includes(categoryName) ||
+        categoryName.includes(g.name?.toLowerCase() || '')
+      );
+      if (!matchesCategory && genreId !== APPLE_CATEGORY_MAP['all']) {
+        continue;
+      }
+    }
+
+    results.push({
+      rank: results.length + 1,
+      appName: entry.name || '',
+      developer: entry.artistName || '',
+      appId: entry.id || '',
+      rating: null, // RSS feed doesn't include ratings
+      ratingCount: null,
+      price: 'Free',
+      inAppPurchases: false,
+      category: primaryGenre,
+      lastUpdated: entry.releaseDate || null,
+      size: null,
+      icon: entry.artworkUrl100 || null,
+    });
+  }
+
+  // Enrich top results with lookup API for ratings
+  const enrichBatch = results.slice(0, Math.min(results.length, 20));
+  if (enrichBatch.length > 0) {
+    const ids = enrichBatch.map(r => r.appId).join(',');
+    try {
+      const lookupUrl = `https://itunes.apple.com/lookup?id=${ids}&country=${cc}`;
+      const lookupData = await appleApiFetch(lookupUrl);
+      const lookupResults = lookupData?.results || [];
+
+      for (const lr of lookupResults) {
+        const match = results.find(r => r.appId === String(lr.trackId));
+        if (match) {
+          match.rating = lr.averageUserRating ? Math.round(lr.averageUserRating * 10) / 10 : null;
+          match.ratingCount = lr.userRatingCount || null;
+          match.price = lr.formattedPrice || (lr.price === 0 ? 'Free' : `$${lr.price}`);
+          match.inAppPurchases = (lr.features || []).includes('iosUniversal') || !!lr.isVppDeviceBasedLicensingEnabled;
+          match.size = lr.fileSizeBytes ? formatBytes(parseInt(lr.fileSizeBytes)) : null;
+          match.lastUpdated = lr.currentVersionReleaseDate?.split('T')[0] || match.lastUpdated;
+          match.icon = lr.artworkUrl100 || match.icon;
+        }
+      }
+    } catch (e) {
+      console.error('[appstore] Failed to enrich Apple rankings with lookup API:', e);
+    }
+  }
+
+  return results.slice(0, safeLimit);
+}
+
+/**
+ * Get detailed app info from Apple App Store.
+ */
+export async function getAppleAppDetail(
+  appId: string,
+  country: string = 'US',
+): Promise<AppDetail> {
+  country = validateCountry(country);
+  const cc = APPLE_COUNTRY_MAP[country] || 'us';
+
+  const lookupUrl = `https://itunes.apple.com/lookup?id=${appId}&country=${cc}`;
+  const data = await appleApiFetch(lookupUrl);
+  const app = data?.results?.[0];
+
+  if (!app) {
+    throw new Error(`App not found: ${appId}`);
+  }
+
+  // Fetch reviews from Apple RSS
+  const reviews = await getAppleReviews(appId, country);
+
+  return {
+    appName: app.trackName || '',
+    developer: app.artistName || '',
+    appId: String(app.trackId),
+    description: (app.description || '').slice(0, 5000),
+    rating: app.averageUserRating ? Math.round(app.averageUserRating * 10) / 10 : null,
+    ratingCount: app.userRatingCount || null,
+    price: app.formattedPrice || (app.price === 0 ? 'Free' : `$${app.price}`),
+    inAppPurchases: Array.isArray(app.ipadScreenshotUrls), // heuristic
+    category: app.primaryGenreName || '',
+    lastUpdated: app.currentVersionReleaseDate?.split('T')[0] || null,
+    size: app.fileSizeBytes ? formatBytes(parseInt(app.fileSizeBytes)) : null,
+    icon: app.artworkUrl512 || app.artworkUrl100 || null,
+    screenshots: (app.screenshotUrls || []).slice(0, 5),
+    version: app.version || null,
+    whatsNew: (app.releaseNotes || '').slice(0, 2000) || null,
+    contentRating: app.contentAdvisoryRating || null,
+    installs: null, // Apple doesn't expose download counts
+    reviews,
+  };
+}
+
+/**
+ * Fetch recent reviews from Apple App Store.
+ */
+async function getAppleReviews(
+  appId: string,
+  country: string = 'US',
+  limit: number = 10,
+): Promise<AppReview[]> {
+  const cc = APPLE_COUNTRY_MAP[country] || 'us';
+  const url = `https://itunes.apple.com/rss/customerreviews/id=${appId}/sortBy=mostRecent/json?cc=${cc}`;
+
+  try {
+    const data = await appleApiFetch(url);
+    const entries = data?.feed?.entry || [];
+    const reviews: AppReview[] = [];
+
+    for (const entry of entries.slice(0, limit)) {
+      if (!entry?.content?.label) continue;
+      reviews.push({
+        author: entry?.author?.name?.label || 'Anonymous',
+        rating: parseInt(entry?.['im:rating']?.label || '0') || 0,
+        title: entry?.title?.label || null,
+        text: (entry?.content?.label || '').slice(0, 2000),
+        date: entry?.updated?.label?.split('T')[0] || null,
+        helpful: parseInt(entry?.['im:voteSum']?.label || '0') || 0,
+      });
+    }
+
+    return reviews;
+  } catch (e) {
+    console.error('[appstore] Failed to fetch Apple reviews:', e);
+    return [];
+  }
+}
+
+/**
+ * Search Apple App Store.
+ */
+export async function searchAppleApps(
+  query: string,
+  country: string = 'US',
+  limit: number = 25,
+): Promise<AppSearchResult[]> {
+  country = validateCountry(country);
+  const cc = APPLE_COUNTRY_MAP[country] || 'us';
+  const safeLimit = Math.min(Math.max(limit, 1), 50);
+
+  const params = new URLSearchParams({
+    term: query,
+    country: cc,
+    media: 'software',
+    limit: String(safeLimit),
+  });
+
+  const url = `https://itunes.apple.com/search?${params}`;
+  const data = await appleApiFetch(url);
+  const results: AppSearchResult[] = [];
+
+  for (const app of (data?.results || [])) {
+    results.push({
+      appName: app.trackName || '',
+      developer: app.artistName || '',
+      appId: String(app.trackId),
+      rating: app.averageUserRating ? Math.round(app.averageUserRating * 10) / 10 : null,
+      ratingCount: app.userRatingCount || null,
+      price: app.formattedPrice || (app.price === 0 ? 'Free' : `$${app.price}`),
+      icon: app.artworkUrl100 || null,
+      description: (app.description || '').slice(0, 500),
+      category: app.primaryGenreName || null,
+    });
+  }
+
+  return results;
+}
+
+// ─── GOOGLE PLAY STORE ──────────────────────────────
+
+async function googlePlayFetch(url: string): Promise<string> {
+  const response = await proxyFetch(url, {
+    headers: {
+      'User-Agent': getRandomUA(),
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Cache-Control': 'no-cache',
+    },
+    maxRetries: 2,
+    timeoutMs: 25_000,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google Play Store returned ${response.status}`);
+  }
+
+  return response.text();
+}
+
+/**
+ * Fetch top app rankings from Google Play Store.
+ */
+export async function getGoogleRankings(
+  category: string = 'all',
+  country: string = 'US',
+  limit: number = 50,
+): Promise<AppRanking[]> {
+  country = validateCountry(country);
+  const gl = GOOGLE_COUNTRY_MAP[country] || 'us';
+  const hl = GOOGLE_LANG_MAP[country] || 'en';
+  const cat = GOOGLE_CATEGORY_MAP[category.toLowerCase()] || '';
+  const safeLimit = Math.min(Math.max(limit, 1), 200);
+
+  let url: string;
+  if (cat) {
+    url = `https://play.google.com/store/apps/category/${cat}/collection/cluster?clp=ogooCAEaHAoWcmVjc190b3BpY19vZTBhYl9tMXh6ZRAHGAMqAggB:S:ANO1ljJhDWY&gsr=CiuiCigIARocChZyZWNzX3RvcGljX29lMGFiX20xeHplEAcYAyoCCAE%3D:S:ANO1ljJ_Qmk&hl=${hl}&gl=${gl}`;
+  } else {
+    url = `https://play.google.com/store/apps/top?hl=${hl}&gl=${gl}`;
+  }
+
+  const html = await googlePlayFetch(url);
+  return parseGooglePlayRankings(html, category, safeLimit);
+}
+
+/**
+ * Parse Google Play Store HTML for app listings.
+ */
+function parseGooglePlayRankings(html: string, category: string, limit: number): AppRanking[] {
+  const results: AppRanking[] = [];
+
+  // Extract app cards from Google Play HTML
+  // Google Play uses data attributes and specific class patterns
+  const appLinkPattern = /href="\/store\/apps\/details\?id=([^"&]+)"/g;
+  const appIds = new Set<string>();
+  let match;
+
+  while ((match = appLinkPattern.exec(html)) !== null) {
+    appIds.add(match[1]);
+  }
+
+  // Extract structured data from script tags
+  const scriptBlocks = extractAllBetween(html, 'AF_initDataCallback(', ');</script>');
+
+  // Parse app info from the HTML structure
+  // Google Play embeds JSON data in script tags
+  for (const block of scriptBlocks) {
+    try {
+      // Look for app data arrays
+      const dataMatch = block.match(/data:(\[[\s\S]*?\])\s*,\s*sideChannel/);
+      if (!dataMatch) continue;
+
+      const rawData = dataMatch[1];
+      // Try to parse nested arrays for app data
+      const parsed = JSON.parse(rawData);
+      extractAppsFromGoogleData(parsed, results, category);
+    } catch {
+      // Parsing individual blocks may fail, continue
+    }
+  }
+
+  // Fallback: parse from HTML patterns if script parsing didn't yield results
+  if (results.length === 0) {
+    parseGooglePlayHtmlFallback(html, results, category, appIds);
+  }
+
+  // Assign ranks
+  for (let i = 0; i < results.length; i++) {
+    results[i].rank = i + 1;
+  }
+
+  return results.slice(0, limit);
+}
+
+function extractAppsFromGoogleData(data: any, results: AppRanking[], category: string): void {
+  if (!Array.isArray(data)) return;
+
+  for (const item of data) {
+    if (!Array.isArray(item)) {
+      continue;
+    }
+
+    // Recurse into nested arrays looking for app data structures
+    // Google Play data typically has: [appName, icon, [details...], appId, developer...]
+    if (typeof item[0] === 'string' && item[0].length > 0 && typeof item[1] === 'string') {
+      // Potential app entry
+      const hasAppId = findStringPattern(item, /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*){2,}$/i);
+      if (hasAppId) {
+        try {
+          const appName = findFirstString(item, 2);
+          const developer = findDeveloperName(item);
+          const rating = findRating(item);
+          const icon = findIconUrl(item);
+
+          if (appName && hasAppId) {
+            results.push({
+              rank: 0,
+              appName,
+              developer: developer || '',
+              appId: hasAppId,
+              rating,
+              ratingCount: null,
+              price: 'Free',
+              inAppPurchases: false,
+              category: category !== 'all' ? category : '',
+              lastUpdated: null,
+              size: null,
+              icon,
+            });
+          }
+        } catch {
+          // Skip malformed entries
+        }
+      }
+    }
+
+    // Recurse
+    if (Array.isArray(item) && item.length > 0) {
+      extractAppsFromGoogleData(item, results, category);
+    }
+  }
+}
+
+function findStringPattern(arr: any, pattern: RegExp): string | null {
+  if (typeof arr === 'string' && pattern.test(arr)) return arr;
+  if (!Array.isArray(arr)) return null;
+  for (const item of arr) {
+    const found = findStringPattern(item, pattern);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findFirstString(arr: any, minLength: number): string | null {
+  if (typeof arr === 'string' && arr.length >= minLength && !arr.startsWith('http')) return arr;
+  if (!Array.isArray(arr)) return null;
+  for (const item of arr) {
+    const found = findFirstString(item, minLength);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findDeveloperName(arr: any): string | null {
+  // Developer names are typically shorter strings that appear after app names
+  if (!Array.isArray(arr)) return null;
+  const strings = flattenStrings(arr).filter(s =>
+    s.length > 1 && s.length < 100 && !s.startsWith('http') && !s.includes('.')
+  );
+  return strings.length > 1 ? strings[1] : null;
+}
+
+function findRating(arr: any): number | null {
+  if (typeof arr === 'number' && arr > 0 && arr <= 5) return Math.round(arr * 10) / 10;
+  if (!Array.isArray(arr)) return null;
+  for (const item of arr) {
+    const found = findRating(item);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findIconUrl(arr: any): string | null {
+  if (typeof arr === 'string' && arr.startsWith('https://play-lh.googleusercontent.com/')) return arr;
+  if (!Array.isArray(arr)) return null;
+  for (const item of arr) {
+    const found = findIconUrl(item);
+    if (found) return found;
+  }
+  return null;
+}
+
+function flattenStrings(arr: any): string[] {
+  const result: string[] = [];
+  if (typeof arr === 'string') {
+    result.push(arr);
+  } else if (Array.isArray(arr)) {
+    for (const item of arr) {
+      result.push(...flattenStrings(item));
+    }
+  }
+  return result;
+}
+
+function parseGooglePlayHtmlFallback(
+  html: string,
+  results: AppRanking[],
+  category: string,
+  appIds: Set<string>,
+): void {
+  // Extract app names near app ID links
+  for (const appId of appIds) {
+    if (results.length >= 200) break;
+
+    // Find the context around the app ID mention
+    const idIdx = html.indexOf(`id=${appId}`);
+    if (idIdx === -1) continue;
+
+    // Extract surrounding HTML (2KB window)
+    const start = Math.max(0, idIdx - 1000);
+    const end = Math.min(html.length, idIdx + 1000);
+    const context = html.slice(start, end);
+
+    // Try to extract app name from nearby text
+    const nameMatch = context.match(/aria-label="([^"]+)"/);
+    const altMatch = context.match(/alt="([^"]+)"/);
+    const titleMatch = context.match(/title="([^"]+)"/);
+    const appName = nameMatch?.[1] || altMatch?.[1] || titleMatch?.[1];
+
+    if (!appName) continue;
+
+    // Extract rating if present
+    const ratingMatch = context.match(/(\d\.\d)\s*star/i) || context.match(/>(\d\.\d)</);
+    const rating = ratingMatch ? parseFloat(ratingMatch[1]) : null;
+
+    // Extract icon
+    const iconMatch = context.match(/src="(https:\/\/play-lh\.googleusercontent\.com\/[^"]+)"/);
+
+    // Avoid duplicates
+    if (results.some(r => r.appId === appId)) continue;
+
+    results.push({
+      rank: 0,
+      appName: decodeEntities(appName),
+      developer: '',
+      appId,
+      rating,
+      ratingCount: null,
+      price: 'Free',
+      inAppPurchases: false,
+      category: category !== 'all' ? category : '',
+      lastUpdated: null,
+      size: null,
+      icon: iconMatch?.[1] || null,
+    });
+  }
+}
+
+/**
+ * Get detailed app info from Google Play Store.
+ */
+export async function getGoogleAppDetail(
+  appId: string,
+  country: string = 'US',
+): Promise<AppDetail> {
+  country = validateCountry(country);
+  const gl = GOOGLE_COUNTRY_MAP[country] || 'us';
+  const hl = GOOGLE_LANG_MAP[country] || 'en';
+
+  const url = `https://play.google.com/store/apps/details?id=${encodeURIComponent(appId)}&hl=${hl}&gl=${gl}`;
+  const html = await googlePlayFetch(url);
+
+  return parseGooglePlayDetail(html, appId);
+}
+
+function parseGooglePlayDetail(html: string, appId: string): AppDetail {
+  // Extract from meta tags and structured HTML
+  const ogTitle = extractBetween(html, 'property="og:title" content="', '"');
+  const ogDesc = extractBetween(html, 'property="og:description" content="', '"');
+  const ogImage = extractBetween(html, 'property="og:image" content="', '"');
+
+  // Extract from schema.org JSON-LD
+  let schemaData: any = null;
+  const ldJson = extractBetween(html, '<script type="application/ld+json">', '</script>');
+  if (ldJson) {
+    try {
+      schemaData = JSON.parse(ldJson);
+    } catch { /* ignore */ }
+  }
+
+  // Extract rating
+  const ratingMatch = html.match(/aria-label="Rated (\d\.?\d?) out of 5 stars"/);
+  const rating = ratingMatch ? parseFloat(ratingMatch[1]) : (schemaData?.aggregateRating?.ratingValue ? parseFloat(schemaData.aggregateRating.ratingValue) : null);
+
+  // Extract rating count
+  const ratingCountMatch = html.match(/([\d,]+)\s*(?:reviews|ratings)/i);
+  const ratingCount = ratingCountMatch ? parseInt(ratingCountMatch[1].replace(/,/g, '')) : (schemaData?.aggregateRating?.ratingCount ? parseInt(schemaData.aggregateRating.ratingCount) : null);
+
+  // Extract installs
+  const installsMatch = html.match(/([\d,]+[KMB]?\+?)\s*downloads/i) || html.match(/installs"[^>]*>([\d,]+[KMB]?\+?)/i);
+  const installs = installsMatch?.[1] || null;
+
+  // Extract developer
+  const developerMatch = html.match(/href="\/store\/apps\/dev[^"]*"[^>]*>([^<]+)</) ||
+    html.match(/"author"[^}]*"name"\s*:\s*"([^"]+)"/);
+  const developer = developerMatch?.[1] || schemaData?.author?.name || '';
+
+  // Extract content rating
+  const contentRatingMatch = html.match(/content rating[^>]*>([^<]+)/i);
+  const contentRating = contentRatingMatch?.[1]?.trim() || null;
+
+  // Extract what's new
+  const whatsNewSection = extractBetween(html, "What's new", '</section>') ||
+    extractBetween(html, 'What&#39;s new', '</section>');
+  const whatsNew = whatsNewSection ? extractText(whatsNewSection).slice(0, 2000) : null;
+
+  // Extract version
+  const versionMatch = html.match(/Current Version[^>]*>([^<]+)/) || html.match(/"softwareVersion"\s*:\s*"([^"]+)"/);
+  const version = versionMatch?.[1]?.trim() || schemaData?.softwareVersion || null;
+
+  // Extract size
+  const sizeMatch = html.match(/Size[^>]*>([\d.]+\s*[KMGT]?B)/i);
+  const size = sizeMatch?.[1] || null;
+
+  // Extract last updated
+  const updatedMatch = html.match(/Updated on[^>]*>([^<]+)/) || html.match(/"dateModified"\s*:\s*"([^"]+)"/);
+  const lastUpdated = updatedMatch?.[1]?.trim() || null;
+
+  // Extract screenshots
+  const screenshotPattern = /src="(https:\/\/play-lh\.googleusercontent\.com\/[^"]*=w\d+[^"]*)"/g;
+  const screenshots: string[] = [];
+  let ssMatch;
+  while ((ssMatch = screenshotPattern.exec(html)) !== null && screenshots.length < 5) {
+    if (!screenshots.includes(ssMatch[1])) {
+      screenshots.push(ssMatch[1]);
+    }
+  }
+
+  // Parse reviews from HTML
+  const reviews = parseGooglePlayReviews(html);
+
+  // Extract price
+  const priceMatch = html.match(/itemprop="price" content="([^"]+)"/);
+  const price = priceMatch?.[1] === '0' ? 'Free' : priceMatch?.[1] || 'Free';
+
+  // Determine in-app purchases
+  const hasIAP = html.includes('In-app purchases') || html.includes('in-app purchases');
+
+  return {
+    appName: decodeEntities(ogTitle || schemaData?.name || ''),
+    developer: decodeEntities(developer),
+    appId,
+    description: decodeEntities((ogDesc || schemaData?.description || '').slice(0, 5000)),
+    rating: rating ? Math.round(rating * 10) / 10 : null,
+    ratingCount,
+    price,
+    inAppPurchases: hasIAP,
+    category: schemaData?.applicationCategory || '',
+    lastUpdated,
+    size,
+    icon: ogImage || null,
+    screenshots,
+    version,
+    whatsNew,
+    contentRating,
+    installs,
+    reviews,
+  };
+}
+
+function parseGooglePlayReviews(html: string): AppReview[] {
+  const reviews: AppReview[] = [];
+
+  // Google Play embeds review data in script tags
+  // Look for review blocks in HTML
+  const reviewBlocks = extractAllBetween(html, 'jscontroller="H6eOGe"', '</div></div></div>');
+
+  for (const block of reviewBlocks.slice(0, 10)) {
+    const authorMatch = block.match(/class="[^"]*"[^>]*>([^<]+)<\/span>/);
+    const ratingMatch = block.match(/aria-label="Rated (\d) stars out of five stars"/);
+    const textMatch = block.match(/jsname="[^"]*"[^>]*>([^<]{10,})<\/span>/);
+    const dateMatch = block.match(/(\w+ \d+, \d{4})/);
+
+    if (textMatch) {
+      reviews.push({
+        author: authorMatch?.[1] || 'Anonymous',
+        rating: ratingMatch ? parseInt(ratingMatch[1]) : 0,
+        title: null,
+        text: decodeEntities(textMatch[1]).slice(0, 2000),
+        date: dateMatch?.[1] || null,
+        helpful: 0,
+      });
+    }
+  }
+
+  return reviews;
+}
+
+/**
+ * Search Google Play Store.
+ */
+export async function searchGoogleApps(
+  query: string,
+  country: string = 'US',
+  limit: number = 25,
+): Promise<AppSearchResult[]> {
+  country = validateCountry(country);
+  const gl = GOOGLE_COUNTRY_MAP[country] || 'us';
+  const hl = GOOGLE_LANG_MAP[country] || 'en';
+  const safeLimit = Math.min(Math.max(limit, 1), 50);
+
+  const params = new URLSearchParams({
+    q: query,
+    c: 'apps',
+    hl,
+    gl,
+  });
+
+  const url = `https://play.google.com/store/search?${params}`;
+  const html = await googlePlayFetch(url);
+
+  return parseGooglePlaySearch(html, safeLimit);
+}
+
+function parseGooglePlaySearch(html: string, limit: number): AppSearchResult[] {
+  const results: AppSearchResult[] = [];
+  const appIds = new Set<string>();
+
+  // Extract app links and surrounding context
+  const appLinkPattern = /href="\/store\/apps\/details\?id=([^"&]+)"/g;
+  let match;
+
+  while ((match = appLinkPattern.exec(html)) !== null) {
+    const appId = match[1];
+    if (appIds.has(appId) || results.length >= limit) continue;
+    appIds.add(appId);
+
+    const start = Math.max(0, match.index - 1500);
+    const end = Math.min(html.length, match.index + 1500);
+    const context = html.slice(start, end);
+
+    const nameMatch = context.match(/aria-label="([^"]+)"/) ||
+      context.match(/title="([^"]+)"/) ||
+      context.match(/alt="([^"]+)"/);
+    const ratingMatch = context.match(/aria-label="Rated (\d\.?\d?)/) ||
+      context.match(/>(\d\.\d)</);
+    const iconMatch = context.match(/src="(https:\/\/play-lh\.googleusercontent\.com\/[^"]+)"/);
+    const descMatch = context.match(/class="[^"]*"[^>]*>([^<]{20,200})<\/span>/);
+
+    const appName = nameMatch?.[1];
+    if (!appName) continue;
+
+    results.push({
+      appName: decodeEntities(appName),
+      developer: '',
+      appId,
+      rating: ratingMatch ? parseFloat(ratingMatch[1]) : null,
+      ratingCount: null,
+      price: 'Free',
+      icon: iconMatch?.[1] || null,
+      description: descMatch ? decodeEntities(descMatch[1]) : '',
+      category: null,
+    });
+  }
+
+  return results;
+}
+
+// ─── UNIFIED PUBLIC API ─────────────────────────────
+
+/**
+ * Get app rankings from either store.
+ */
+export async function getRankings(
+  store: 'apple' | 'google',
+  category: string = 'all',
+  country: string = 'US',
+  limit: number = 50,
+): Promise<AppRanking[]> {
+  if (store === 'apple') {
+    return getAppleRankings(category, country, limit);
+  }
+  return getGoogleRankings(category, country, limit);
+}
+
+/**
+ * Get detailed app info from either store.
+ */
+export async function getAppDetail(
+  store: 'apple' | 'google',
+  appId: string,
+  country: string = 'US',
+): Promise<AppDetail> {
+  if (store === 'apple') {
+    return getAppleAppDetail(appId, country);
+  }
+  return getGoogleAppDetail(appId, country);
+}
+
+/**
+ * Search apps in either store.
+ */
+export async function searchApps(
+  store: 'apple' | 'google',
+  query: string,
+  country: string = 'US',
+  limit: number = 25,
+): Promise<AppSearchResult[]> {
+  if (store === 'apple') {
+    return searchAppleApps(query, country, limit);
+  }
+  return searchGoogleApps(query, country, limit);
+}
+
+/**
+ * Get trending/new apps from either store.
+ * Uses the top charts with "new" collection for trending apps.
+ */
+export async function getTrendingApps(
+  store: 'apple' | 'google',
+  country: string = 'US',
+  limit: number = 25,
+): Promise<TrendingApp[]> {
+  country = validateCountry(country);
+
+  if (store === 'apple') {
+    return getAppleTrending(country, limit);
+  }
+  return getGoogleTrending(country, limit);
+}
+
+async function getAppleTrending(country: string, limit: number): Promise<TrendingApp[]> {
+  const cc = APPLE_COUNTRY_MAP[country] || 'us';
+  const safeLimit = Math.min(Math.max(limit, 1), 100);
+
+  // Use the "top free" feed to get current trending
+  const url = `https://rss.applemarketingtools.com/api/v2/${cc}/apps/top-free/${safeLimit}/apps.json`;
+  const data = await appleApiFetch(url);
+
+  const entries = data?.feed?.results || [];
+  const results: TrendingApp[] = [];
+
+  for (let i = 0; i < Math.min(entries.length, safeLimit); i++) {
+    const entry = entries[i];
+    results.push({
+      rank: i + 1,
+      appName: entry.name || '',
+      developer: entry.artistName || '',
+      appId: entry.id || '',
+      rating: null,
+      ratingCount: null,
+      price: 'Free',
+      icon: entry.artworkUrl100 || null,
+      category: entry.genres?.[0]?.name || null,
+      growthSignal: i < 10 ? 'top-10' : i < 25 ? 'top-25' : 'charting',
+    });
+  }
+
+  return results;
+}
+
+async function getGoogleTrending(country: string, limit: number): Promise<TrendingApp[]> {
+  const gl = GOOGLE_COUNTRY_MAP[country] || 'us';
+  const hl = GOOGLE_LANG_MAP[country] || 'en';
+  const safeLimit = Math.min(Math.max(limit, 1), 100);
+
+  const url = `https://play.google.com/store/apps/top?hl=${hl}&gl=${gl}`;
+  const html = await googlePlayFetch(url);
+
+  const rankings = parseGooglePlayRankings(html, 'all', safeLimit);
+
+  return rankings.map((app, i) => ({
+    rank: i + 1,
+    appName: app.appName,
+    developer: app.developer,
+    appId: app.appId,
+    rating: app.rating,
+    ratingCount: app.ratingCount,
+    price: app.price,
+    icon: app.icon,
+    category: app.category || null,
+    growthSignal: i < 10 ? 'top-10' : i < 25 ? 'top-25' : 'charting',
+  }));
+}
+
+// ─── UTILITY ────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -20,6 +20,7 @@ import { fetchReviews, fetchBusinessDetails, fetchReviewSummary, searchBusinesse
 import { scrapeGoogleMaps, extractDetailedBusiness } from './scrapers/maps-scraper';
 import { researchRouter } from './routes/research';
 import { trendingRouter } from './routes/trending';
+import { appstoreRouter } from './routes/appstore';
 import { searchAirbnb, getListingDetail, getListingReviews, getMarketStats } from './scrapers/airbnb-scraper';
 import { 
   scrapeLinkedInPerson, 
@@ -35,6 +36,9 @@ export const serviceRouter = new Hono();
 // ─── TREND INTELLIGENCE ROUTES (Bounty #70) ─────────
 serviceRouter.route('/research', researchRouter);
 serviceRouter.route('/trending', trendingRouter);
+
+// ─── APP STORE INTELLIGENCE ROUTES (Bounty #54) ─────
+serviceRouter.route('/appstore', appstoreRouter);
 
 const SERVICE_NAME = 'job-market-intelligence';
 const PRICE_USDC = 0.005;

--- a/tests/appstore-endpoints.test.ts
+++ b/tests/appstore-endpoints.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x1111111111111111111111111111111111111111';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_01 = '0x0000000000000000000000000000000000000000000000000000000000002710';
+const USDC_AMOUNT_0_02 = '0x0000000000000000000000000000000000000000000000000000000000004e20';
+const USDC_AMOUNT_0_03 = '0x0000000000000000000000000000000000000000000000000000000000007530';
+
+// Sample Apple RSS feed response
+const APPLE_RSS_RESPONSE = {
+  feed: {
+    results: [
+      { id: '123456', name: 'Test App 1', artistName: 'Dev Corp', artworkUrl100: 'https://example.com/icon1.png', genres: [{ name: 'Games' }], releaseDate: '2026-03-01' },
+      { id: '789012', name: 'Test App 2', artistName: 'Indie Dev', artworkUrl100: 'https://example.com/icon2.png', genres: [{ name: 'Utilities' }], releaseDate: '2026-03-10' },
+    ],
+  },
+};
+
+// Sample Apple lookup response
+const APPLE_LOOKUP_RESPONSE = {
+  resultCount: 2,
+  results: [
+    { trackId: 123456, trackName: 'Test App 1', artistName: 'Dev Corp', averageUserRating: 4.7, userRatingCount: 125000, formattedPrice: 'Free', fileSizeBytes: '256000000', artworkUrl100: 'https://example.com/icon1.png', primaryGenreName: 'Games', currentVersionReleaseDate: '2026-03-01T00:00:00Z' },
+    { trackId: 789012, trackName: 'Test App 2', artistName: 'Indie Dev', averageUserRating: 4.2, userRatingCount: 5000, formattedPrice: 'Free', fileSizeBytes: '52000000', artworkUrl100: 'https://example.com/icon2.png', primaryGenreName: 'Utilities', currentVersionReleaseDate: '2026-03-10T00:00:00Z' },
+  ],
+};
+
+// Sample Apple search response
+const APPLE_SEARCH_RESPONSE = {
+  resultCount: 2,
+  results: [
+    { trackId: 111111, trackName: 'VPN Master', artistName: 'VPN Inc', averageUserRating: 4.5, userRatingCount: 80000, formattedPrice: 'Free', artworkUrl100: 'https://example.com/vpn.png', description: 'Fast and secure VPN', primaryGenreName: 'Utilities' },
+    { trackId: 222222, trackName: 'VPN Shield', artistName: 'Shield Co', averageUserRating: 4.1, userRatingCount: 12000, formattedPrice: '$4.99', artworkUrl100: 'https://example.com/shield.png', description: 'Privacy VPN solution', primaryGenreName: 'Utilities' },
+  ],
+};
+
+// Sample Apple app detail response
+const APPLE_DETAIL_RESPONSE = {
+  resultCount: 1,
+  results: [
+    { trackId: 123456, trackName: 'Test App 1', artistName: 'Dev Corp', averageUserRating: 4.7, userRatingCount: 125000, formattedPrice: 'Free', fileSizeBytes: '256000000', artworkUrl100: 'https://example.com/icon1.png', artworkUrl512: 'https://example.com/icon1_512.png', primaryGenreName: 'Games', currentVersionReleaseDate: '2026-03-01T00:00:00Z', description: 'An amazing game.', version: '3.2.1', releaseNotes: 'Bug fixes and improvements', contentAdvisoryRating: '4+', screenshotUrls: ['https://example.com/ss1.png'] },
+  ],
+};
+
+// Sample Apple reviews response
+const APPLE_REVIEWS_RESPONSE = {
+  feed: {
+    entry: [
+      { author: { name: { label: 'JohnDoe' } }, 'im:rating': { label: '5' }, title: { label: 'Great app' }, content: { label: 'Really love this app, works perfectly.' }, updated: { label: '2026-03-12T00:00:00Z' }, 'im:voteSum': { label: '3' } },
+      { author: { name: { label: 'JaneSmith' } }, 'im:rating': { label: '2' }, title: { label: 'Disappointing' }, content: { label: 'Too many bugs and crashes frequently.' }, updated: { label: '2026-03-11T00:00:00Z' }, 'im:voteSum': { label: '1' } },
+    ],
+  },
+};
+
+let txCounter = 100;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function installFetchMock(recipientAddress: string, usdcAmount: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    // Base RPC for payment verification
+    if (url.includes('mainnet.base.org')) {
+      const payload = init?.body ? JSON.parse(String(init.body)) : {};
+      if (payload?.method !== 'eth_getTransactionReceipt') {
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(recipientAddress),
+            ],
+            data: usdcAmount,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Apple RSS feed
+    if (url.includes('rss.applemarketingtools.com')) {
+      return new Response(JSON.stringify(APPLE_RSS_RESPONSE), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Apple iTunes lookup
+    if (url.includes('itunes.apple.com/lookup')) {
+      // Check if looking up specific app
+      if (url.includes('id=123456') && !url.includes(',')) {
+        return new Response(JSON.stringify(APPLE_DETAIL_RESPONSE), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify(APPLE_LOOKUP_RESPONSE), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Apple search
+    if (url.includes('itunes.apple.com/search')) {
+      return new Response(JSON.stringify(APPLE_SEARCH_RESPONSE), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Apple reviews RSS
+    if (url.includes('itunes.apple.com/rss/customerreviews')) {
+      return new Response(JSON.stringify(APPLE_REVIEWS_RESPONSE), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Google Play Store
+    if (url.includes('play.google.com')) {
+      return new Response('<html><body><a href="/store/apps/details?id=com.test.app1" title="Test Google App">Test Google App</a></body></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+
+    // Proxy IP check
+    if (url.includes('api.ipify.org')) {
+      return new Response(JSON.stringify({ ip: '198.51.100.1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('App Store Intelligence endpoints', () => {
+  // ─── 402 PAYMENT REQUIRED TESTS ─────────────────
+
+  test('GET /api/appstore/rankings returns 402 without payment', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/rankings?store=apple&category=games&country=US'),
+    );
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/appstore/rankings');
+    expect(body.price.amount).toBe('0.01');
+    expect(body.message).toBe('Payment required');
+    expect(body.outputSchema).toBeDefined();
+  });
+
+  test('GET /api/appstore/app returns 402 without payment', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/app?store=apple&appId=123456'),
+    );
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/appstore/app');
+    expect(body.price.amount).toBe('0.02');
+  });
+
+  test('GET /api/appstore/search returns 402 without payment', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/search?store=apple&query=vpn'),
+    );
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/appstore/search');
+    expect(body.price.amount).toBe('0.01');
+  });
+
+  test('GET /api/appstore/trending returns 402 without payment', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/trending?store=apple'),
+    );
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/appstore/trending');
+  });
+
+  test('GET /api/appstore/compare returns 402 without payment', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/compare?store=apple&appIds=123456,789012'),
+    );
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/appstore/compare');
+    expect(body.price.amount).toBe('0.03');
+  });
+
+  // ─── VALIDATION TESTS ──────────────────────────
+
+  test('GET /api/appstore/rankings returns 400 without store param', async () => {
+    const calls = installFetchMock(TEST_WALLET, USDC_AMOUNT_0_01);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/rankings?category=games', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error).toContain('store');
+  });
+
+  test('GET /api/appstore/search returns 400 without query param', async () => {
+    const calls = installFetchMock(TEST_WALLET, USDC_AMOUNT_0_01);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/search?store=apple', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error).toContain('query');
+  });
+
+  // ─── PAID REQUEST TESTS ────────────────────────
+
+  test('GET /api/appstore/rankings returns 200 for Apple with valid payment', async () => {
+    const calls = installFetchMock(TEST_WALLET, USDC_AMOUNT_0_01);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/rankings?store=apple&category=all&country=US&limit=10', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Payment-Settled')).toBe('true');
+
+    const body = await res.json() as any;
+    expect(body.type).toBe('rankings');
+    expect(body.store).toBe('apple');
+    expect(body.country).toBe('US');
+    expect(Array.isArray(body.rankings)).toBe(true);
+    expect(body.rankings.length).toBeGreaterThan(0);
+    expect(body.rankings[0].appName).toBe('Test App 1');
+    expect(body.rankings[0].rank).toBe(1);
+    expect(body.proxy.type).toBe('mobile');
+    expect(body.payment.txHash).toBe(txHash);
+    expect(body.payment.network).toBe('base');
+    expect(body.payment.settled).toBe(true);
+    expect(body.metadata.totalRanked).toBeGreaterThan(0);
+  });
+
+  test('GET /api/appstore/search returns 200 for Apple search with valid payment', async () => {
+    const calls = installFetchMock(TEST_WALLET, USDC_AMOUNT_0_01);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/search?store=apple&query=vpn&country=GB', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.type).toBe('search');
+    expect(body.store).toBe('apple');
+    expect(body.query).toBe('vpn');
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results.length).toBe(2);
+    expect(body.results[0].appName).toBe('VPN Master');
+    expect(body.payment.settled).toBe(true);
+  });
+
+  test('GET /api/appstore/app returns 200 for Apple app detail with valid payment', async () => {
+    const calls = installFetchMock(TEST_WALLET, USDC_AMOUNT_0_02);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/app?store=apple&appId=123456&country=US', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.type).toBe('app');
+    expect(body.store).toBe('apple');
+    expect(body.app.appName).toBe('Test App 1');
+    expect(body.app.developer).toBe('Dev Corp');
+    expect(body.app.rating).toBe(4.7);
+    expect(body.app.ratingCount).toBe(125000);
+    expect(Array.isArray(body.app.reviews)).toBe(true);
+    expect(body.reviewSentiment).toBeDefined();
+    expect(body.reviewSentiment.overall).toBeDefined();
+    expect(body.payment.settled).toBe(true);
+  });
+
+  test('GET /api/appstore/trending returns 200 for Apple trending with valid payment', async () => {
+    const calls = installFetchMock(TEST_WALLET, USDC_AMOUNT_0_01);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/appstore/trending?store=apple&country=DE&limit=5', {
+        headers: {
+          'X-Payment-Signature': txHash,
+          'X-Payment-Network': 'base',
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.type).toBe('trending');
+    expect(body.store).toBe('apple');
+    expect(Array.isArray(body.trending)).toBe(true);
+    expect(body.trending.length).toBeGreaterThan(0);
+    expect(body.trending[0].rank).toBe(1);
+    expect(body.trending[0].growthSignal).toBeDefined();
+    expect(body.payment.settled).toBe(true);
+  });
+
+  // ─── HEALTH + DISCOVERY ────────────────────────
+
+  test('GET /health includes appstore endpoints', async () => {
+    const res = await app.fetch(new Request('http://localhost/health'));
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.endpoints).toContain('/api/appstore/rankings');
+    expect(body.endpoints).toContain('/api/appstore/app');
+    expect(body.endpoints).toContain('/api/appstore/search');
+    expect(body.endpoints).toContain('/api/appstore/trending');
+    expect(body.endpoints).toContain('/api/appstore/compare');
+  });
+
+  test('GET / includes appstore endpoints in service discovery', async () => {
+    const res = await app.fetch(new Request('http://localhost/'));
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    const paths = body.endpoints.map((e: any) => e.path);
+    expect(paths).toContain('/api/appstore/rankings');
+    expect(paths).toContain('/api/appstore/app');
+    expect(paths).toContain('/api/appstore/search');
+    expect(paths).toContain('/api/appstore/trending');
+    expect(paths).toContain('/api/appstore/compare');
+  });
+});


### PR DESCRIPTION
## Bounty #54 — App Store Intelligence API

Closes #54

### What's Built

Real-time app store intelligence API for **Apple App Store** and **Google Play Store**, scraped through real 4G/5G mobile carrier IPs via `proxyFetch()`.

### Endpoints

| Endpoint | Description | Price |
|----------|-------------|-------|
| `GET /api/appstore/rankings` | Top app charts by category + country (up to 200) | $0.01 |
| `GET /api/appstore/app` | App detail + reviews + sentiment analysis | $0.02 |
| `GET /api/appstore/search` | Keyword search across app stores | $0.01 |
| `GET /api/appstore/trending` | Trending/new app discovery | $0.01 |
| `GET /api/appstore/compare` | Side-by-side comparison of 2-5 apps | $0.03 |

### Technical Requirements Met

- **Mobile proxy**: All scraping uses `proxyFetch()` with real 4G/5G carrier IPs
- **Both stores**: Apple App Store (iTunes API + RSS feeds) + Google Play Store (HTML scraping)
- **x402 payment**: Full 402 → pay → `Payment-Signature` → data flow
- **Country support**: All 6 countries — US, DE, FR, ES, GB, PL
- **Structured JSON**: Clean typed output matching the issue schema
- **Pricing**: $0.01-0.03/query

### Data Points Extracted

- [x] Top app rankings by category and country (top 50-200)
- [x] App metadata: name, developer, rating, review count, price, size, last update
- [x] Recent reviews with rating, text, date, reviewer
- [x] App search results by keyword
- [x] Trending/new apps
- [x] Review sentiment analysis (positive/neutral/negative breakdown)
- [x] Competitor comparison with side-by-side metrics
- [x] In-app purchase detection
- [x] Version history / changelog (whatsNew field)

### Architecture

```
src/
├── scrapers/appstore-scraper.ts  ← Core scraper (Apple iTunes API + Google Play HTML)
├── routes/appstore.ts            ← 5 route handlers with x402 payment verification
├── service.ts                    ← Router registration (appstoreRouter)
└── index.ts                      ← Health + discovery endpoint updates
listings/appstore-intelligence.json ← Marketplace listing
tests/appstore-endpoints.test.ts    ← Test suite
```

### Apple App Store Strategy
- **Rankings**: Apple Marketing Tools RSS feed (`rss.applemarketingtools.com`)
- **App detail**: iTunes Lookup API (`itunes.apple.com/lookup`)
- **Search**: iTunes Search API (`itunes.apple.com/search`)
- **Reviews**: iTunes RSS customer reviews feed
- **Enrichment**: Batch lookup for ratings/size on ranking results

### Google Play Store Strategy
- **Rankings**: HTML scraping of `/store/apps/top` and category pages
- **App detail**: HTML scraping of `/store/apps/details` with schema.org + meta tag extraction
- **Search**: HTML scraping of `/store/search` results
- **Reviews**: Extracted from embedded review blocks in app detail pages

### Example Usage

```bash
# Rankings (returns 402 with payment instructions)
curl "localhost:3000/api/appstore/rankings?store=apple&category=games&country=US"

# Search
curl "localhost:3000/api/appstore/search?store=google&query=vpn&country=DE"

# App detail
curl "localhost:3000/api/appstore/app?store=apple&appId=284882215&country=US"

# Trending
curl "localhost:3000/api/appstore/trending?store=google&country=GB"

# Compare competitors
curl "localhost:3000/api/appstore/compare?store=apple&appIds=284882215,544007664&country=US"
```

### Why Mobile Proxies

Google Play bans datacenter IPs after ~500-1K requests/day. Apple geo-fences rankings by country AND carrier. Mobile carrier IPs appear as legitimate app store users, bypassing all IP reputation checks and geo-restrictions. This replaces $30K-$100K/year tools (Sensor Tower, data.ai) with x402 micropayments at $0.01/query.

### Wallet

`6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv` (Solana USDC)