### PR TITLE
﻿feat: add paid instagram discover endpoint with filtering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ app.get('/health', (c) => c.json({
     '/api/instagram/analyze/:username',
     '/api/instagram/analyze/:username/images',
     '/api/instagram/audit/:username',
+    '/api/instagram/discover',
     '/api/airbnb/search',
     '/api/airbnb/listing/:id',
     '/api/airbnb/reviews/:listing_id',
@@ -123,6 +124,7 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/instagram/analyze/:username', description: 'Full Instagram analysis with AI vision', price: '0.15 USDC' },
     { method: 'GET', path: '/api/instagram/analyze/:username/images', description: 'AI vision analysis of Instagram images', price: '0.08 USDC' },
     { method: 'GET', path: '/api/instagram/audit/:username', description: 'Instagram authenticity audit', price: '0.05 USDC' },
+    { method: 'GET', path: '/api/instagram/discover', description: 'Discover Instagram accounts by AI-derived filters', price: '0.03 USDC' },
     { method: 'GET', path: '/api/airbnb/search', description: 'Search Airbnb listings by location', price: '0.02 USDC' },
     { method: 'GET', path: '/api/airbnb/listing/:id', description: 'Get detailed Airbnb listing', price: '0.01 USDC' },
     { method: 'GET', path: '/api/airbnb/reviews/:listing_id', description: 'Get Airbnb listing reviews', price: '0.01 USDC' },
@@ -162,7 +164,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/audit/:username', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/analyze/:username/images', '/api/instagram/audit/:username', '/api/instagram/discover', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/scrapers/instagram-scraper.ts
+++ b/src/scrapers/instagram-scraper.ts
@@ -55,6 +55,31 @@ export interface AIAnalysis {
 
 export interface FullAnalysis { profile: InstagramProfile; posts: InstagramPost[]; ai_analysis: AIAnalysis; }
 
+export interface DiscoverFilters {
+  niche?: string;
+  min_followers?: number;
+  account_type?: string;
+  sentiment?: string;
+  brand_safe?: boolean;
+  limit?: number;
+}
+
+export interface DiscoverMatch {
+  username: string;
+  match_score: number;
+  match_reasons: string[];
+  profile: InstagramProfile;
+  ai_analysis: AIAnalysis;
+}
+
+export interface DiscoverResult {
+  accounts: DiscoverMatch[];
+  total_processed: number;
+  total_matched: number;
+  skipped: Array<{ username: string; reason: string }>;
+  filters: DiscoverFilters;
+}
+
 // ─── Helpers ────────────────────────────────────────
 
 function cleanText(s: string): string {
@@ -359,4 +384,125 @@ export async function analyzeImages(username: string): Promise<{ images_analyzed
 export async function auditProfile(username: string): Promise<{ profile: InstagramProfile; authenticity: AuthenticityAnalysis }> {
   const full = await analyzeProfile(username);
   return { profile: full.profile, authenticity: full.ai_analysis.authenticity };
+}
+
+function includesCaseInsensitive(values: string[], expected: string): boolean {
+  const target = expected.trim().toLowerCase();
+  return values.some(value => value.toLowerCase().includes(target));
+}
+
+function buildDiscoverMatch(
+  analysis: FullAnalysis,
+  filters: DiscoverFilters,
+): { isMatch: boolean; score: number; reasons: string[] } {
+  const reasons: string[] = [];
+  let criteriaCount = 0;
+  let passedCount = 0;
+
+  if (filters.niche) {
+    criteriaCount++;
+    const niche = filters.niche.toLowerCase();
+    const matchesNiche =
+      analysis.ai_analysis.account_type.niche.toLowerCase().includes(niche) ||
+      includesCaseInsensitive(analysis.ai_analysis.content_themes.top_themes, niche);
+    if (matchesNiche) {
+      passedCount++;
+      reasons.push(`niche:${filters.niche}`);
+    }
+  }
+
+  if (typeof filters.min_followers === 'number') {
+    criteriaCount++;
+    if (analysis.profile.followers >= filters.min_followers) {
+      passedCount++;
+      reasons.push(`followers>=${filters.min_followers}`);
+    }
+  }
+
+  if (filters.account_type) {
+    criteriaCount++;
+    if (analysis.ai_analysis.account_type.primary.toLowerCase() === filters.account_type.toLowerCase()) {
+      passedCount++;
+      reasons.push(`account_type:${filters.account_type}`);
+    }
+  }
+
+  if (filters.sentiment) {
+    criteriaCount++;
+    if (analysis.ai_analysis.sentiment.overall.toLowerCase() === filters.sentiment.toLowerCase()) {
+      passedCount++;
+      reasons.push(`sentiment:${filters.sentiment}`);
+    }
+  }
+
+  if (filters.brand_safe) {
+    criteriaCount++;
+    if (analysis.ai_analysis.content_themes.brand_safety_score >= 70) {
+      passedCount++;
+      reasons.push('brand_safe:true');
+    }
+  }
+
+  if (criteriaCount === 0) {
+    return { isMatch: true, score: 100, reasons: ['no_filters_applied'] };
+  }
+
+  const isMatch = passedCount === criteriaCount;
+  const score = Math.round((passedCount / criteriaCount) * 100);
+  return { isMatch, score, reasons };
+}
+
+export async function discoverAccounts(
+  usernames: string[],
+  filters: DiscoverFilters = {},
+): Promise<DiscoverResult> {
+  const uniqueUsernames = [...new Set(usernames.map(u => u.trim().toLowerCase()).filter(Boolean))];
+  const checks = await Promise.all(uniqueUsernames.map(async username => {
+    try {
+      const analysis = await analyzeProfile(username);
+      return { ok: true as const, username, analysis };
+    } catch (error: any) {
+      return {
+        ok: false as const,
+        username,
+        reason: error?.message || String(error || 'Unknown error'),
+      };
+    }
+  }));
+
+  const accounts: DiscoverMatch[] = [];
+  const skipped: Array<{ username: string; reason: string }> = [];
+
+  for (const result of checks) {
+    if (!result.ok) {
+      skipped.push({ username: result.username, reason: result.reason });
+      continue;
+    }
+
+    const { username, analysis } = result;
+    const { isMatch, score, reasons } = buildDiscoverMatch(analysis, filters);
+    if (!isMatch) continue;
+
+    accounts.push({
+      username,
+      match_score: score,
+      match_reasons: reasons,
+      profile: analysis.profile,
+      ai_analysis: analysis.ai_analysis,
+    });
+  }
+
+  accounts.sort((a, b) => {
+    if (b.match_score !== a.match_score) return b.match_score - a.match_score;
+    return b.profile.followers - a.profile.followers;
+  });
+
+  const limit = Math.max(1, Math.min(filters.limit || 20, 50));
+  return {
+    accounts: accounts.slice(0, limit),
+    total_processed: uniqueUsernames.length,
+    total_matched: accounts.length,
+    skipped,
+    filters: { ...filters, limit },
+  };
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -27,7 +27,7 @@ import {
   searchLinkedInPeople, 
   findCompanyEmployees 
 } from './scrapers/linkedin-enrichment';
-import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile } from './scrapers/instagram-scraper';
+import { getProfile, getPosts, analyzeProfile, analyzeImages, auditProfile, discoverAccounts } from './scrapers/instagram-scraper';
 import { searchReddit, getSubreddit, getTrending, getComments } from './scrapers/reddit-scraper';
 
 export const serviceRouter = new Hono();
@@ -1016,6 +1016,7 @@ const IG_POSTS_PRICE    = 0.02;   // $0.02 per posts fetch
 const IG_ANALYZE_PRICE  = 0.15;   // $0.15 per full analysis (includes AI vision)
 const IG_IMAGES_PRICE   = 0.08;   // $0.08 per image-only analysis
 const IG_AUDIT_PRICE    = 0.05;   // $0.05 per authenticity audit
+const IG_DISCOVER_PRICE = 0.03;   // $0.03 per filtered discovery batch
 
 // ─── GET /api/instagram/profile/:username ───────────
 
@@ -1248,6 +1249,89 @@ serviceRouter.get('/instagram/audit/:username', async (c) => {
     });
   } catch (err: any) {
     return c.json({ error: 'Instagram audit failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ─── GET /api/instagram/discover ─────────────────────
+
+serviceRouter.get('/instagram/discover', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(build402Response('/api/instagram/discover', 'Discover accounts with AI filters: niche, follower floor, account type, sentiment, brand safety', IG_DISCOVER_PRICE, walletAddress, {
+      input: {
+        usernames: 'string (required) — comma-separated usernames to evaluate (max 20)',
+        niche: 'string (optional)',
+        min_followers: 'number (optional)',
+        account_type: 'string (optional) — influencer|business|personal|bot_fake|meme_page|news_media',
+        sentiment: 'string (optional) — positive|neutral|negative|mixed',
+        brand_safe: 'boolean (optional)',
+        limit: 'number (optional, default: 20, max: 50)',
+      },
+      output: {
+        accounts: 'DiscoverMatch[] — username, match_score, match_reasons, profile, ai_analysis',
+        total_processed: 'number',
+        total_matched: 'number',
+        skipped: '{ username, reason }[]',
+      },
+    }), 402);
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, IG_DISCOVER_PRICE);
+  if (!verification.valid) return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+
+  const clientIp = c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (!checkProxyRateLimit(clientIp)) {
+    c.header('Retry-After', '60');
+    return c.json({ error: 'Proxy rate limit exceeded. Max 20 requests/min to protect proxy quota.', retryAfter: 60 }, 429);
+  }
+
+  const usernamesRaw = c.req.query('usernames');
+  if (!usernamesRaw) return c.json({ error: 'Missing required query parameter: usernames' }, 400);
+
+  const usernames = usernamesRaw
+    .split(',')
+    .map(s => s.trim().replace(/^@/, ''))
+    .filter(Boolean)
+    .slice(0, 20);
+
+  if (!usernames.length) return c.json({ error: 'No valid usernames found in usernames query parameter' }, 400);
+
+  const minFollowersRaw = c.req.query('min_followers');
+  const brandSafeRaw = c.req.query('brand_safe');
+  const limitRaw = c.req.query('limit');
+
+  const min_followers = minFollowersRaw ? Math.max(0, parseInt(minFollowersRaw) || 0) : undefined;
+  const limit = Math.max(1, Math.min(limitRaw ? parseInt(limitRaw) || 20 : 20, 50));
+
+  const filters = {
+    niche: c.req.query('niche') || undefined,
+    min_followers,
+    account_type: c.req.query('account_type') || undefined,
+    sentiment: c.req.query('sentiment') || undefined,
+    brand_safe: brandSafeRaw === 'true' ? true : undefined,
+    limit,
+  };
+
+  try {
+    const proxy = getProxy();
+    const result = await discoverAccounts(usernames, filters);
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      ...result,
+      meta: {
+        usernames_submitted: usernames.length,
+        proxy: { country: proxy.country, type: 'mobile' },
+      },
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({ error: 'Instagram discover failed', message: err?.message || String(err) }, 502);
   }
 });
 

--- a/tests/instagram-endpoints.test.ts
+++ b/tests/instagram-endpoints.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import app from '../src/index';
+
+const TEST_WALLET = '0x1111111111111111111111111111111111111111';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const USDC_AMOUNT_0_03 = '0x0000000000000000000000000000000000000000000000000000000000007530';
+
+let txCounter = 1000;
+let restoreFetch: (() => void) | null = null;
+
+function nextBaseTxHash(): string {
+  return `0x${(txCounter++).toString(16).padStart(64, '0')}`;
+}
+
+function toTopicAddress(address: string): string {
+  return `0x${'0'.repeat(24)}${address.toLowerCase().replace(/^0x/, '')}`;
+}
+
+function buildInstagramUser(
+  username: string,
+  followers: number,
+  captions: string[],
+  isBusiness = false,
+): any {
+  return {
+    username,
+    full_name: username === 'traveljane' ? 'Jane Travel' : 'Biz Account',
+    biography: username === 'traveljane'
+      ? 'Travel influencer. #ad collabs welcome.'
+      : 'Business profile for local products.',
+    profile_pic_url: 'https://example.com/pic.jpg',
+    edge_followed_by: { count: followers },
+    edge_follow: { count: 500 },
+    edge_owner_to_timeline_media: {
+      count: captions.length,
+      edges: captions.map((caption, i) => ({
+        node: {
+          id: `${username}-${i + 1}`,
+          shortcode: `${username.toUpperCase()}${i + 1}`,
+          __typename: 'GraphImage',
+          edge_media_to_caption: { edges: [{ node: { text: caption } }] },
+          edge_liked_by: { count: 1200 - i * 50 },
+          edge_media_to_comment: { count: 70 - i * 3 },
+          taken_at_timestamp: 1712500000 - i * 86400,
+          display_url: `https://example.com/${username}-${i + 1}.jpg`,
+          video_url: null,
+          is_ad: caption.includes('#ad'),
+        },
+      })),
+    },
+    is_verified: false,
+    is_business_account: isBusiness,
+    is_private: false,
+    category_name: isBusiness ? 'Business' : 'Creator',
+    external_url: null,
+  };
+}
+
+function installFetchMock(recipientAddress: string): string[] {
+  const calls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  const users: Record<string, any> = {
+    traveljane: buildInstagramUser(
+      'traveljane',
+      125000,
+      [
+        'Amazing travel adventure in Bali #travel #lifestyle #ad',
+        'Sunset at the beach and food tour #travel #food',
+        'Mountain hiking weekend #adventure #travel',
+      ],
+      false,
+    ),
+    bizco: buildInstagramUser(
+      'bizco',
+      8500,
+      [
+        'New product launch this week #business',
+        'Office highlights and team culture #startup',
+      ],
+      true,
+    ),
+  };
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    calls.push(url);
+
+    if (url.includes('mainnet.base.org')) {
+      const payload = init?.body ? JSON.parse(String(init.body)) : {};
+      if (payload?.method !== 'eth_getTransactionReceipt') {
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          status: '0x1',
+          logs: [{
+            address: USDC_BASE,
+            topics: [
+              TRANSFER_TOPIC,
+              toTopicAddress('0x0000000000000000000000000000000000000000'),
+              toTopicAddress(recipientAddress),
+            ],
+            data: USDC_AMOUNT_0_03,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.startsWith('https://i.instagram.com/api/v1/users/web_profile_info/')) {
+      const username = new URL(url).searchParams.get('username') || '';
+      const user = users[username];
+      if (!user) {
+        return new Response(JSON.stringify({ data: { user: null } }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ data: { user } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  }) as typeof fetch;
+
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+  };
+
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.WALLET_ADDRESS = TEST_WALLET;
+  process.env.PROXY_HOST = 'proxy.test.local';
+  process.env.PROXY_HTTP_PORT = '8080';
+  process.env.PROXY_USER = 'tester';
+  process.env.PROXY_PASS = 'secret';
+  process.env.PROXY_COUNTRY = 'US';
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+afterEach(() => {
+  if (restoreFetch) {
+    restoreFetch();
+    restoreFetch = null;
+  }
+});
+
+describe('Instagram discover endpoint', () => {
+  test('GET /api/instagram/discover returns 402 when payment is missing', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/instagram/discover?usernames=traveljane,bizco'),
+    );
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as any;
+
+    expect(body.status).toBe(402);
+    expect(body.resource).toBe('/api/instagram/discover');
+    expect(body.price.amount).toBe('0.03');
+  });
+
+  test('GET /api/instagram/discover returns filtered matches for a valid paid request', async () => {
+    const calls = installFetchMock(TEST_WALLET);
+    const txHash = nextBaseTxHash();
+
+    const res = await app.fetch(
+      new Request(
+        'http://localhost/api/instagram/discover?usernames=traveljane,bizco&niche=travel&min_followers=10000&account_type=influencer&sentiment=neutral&brand_safe=true&limit=5',
+        {
+          headers: {
+            'X-Payment-Signature': txHash,
+            'X-Payment-Network': 'base',
+          },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Payment-Settled')).toBe('true');
+    expect(calls.some(url => url.includes('mainnet.base.org'))).toBe(true);
+    expect(calls.some(url => url.includes('i.instagram.com/api/v1/users/web_profile_info'))).toBe(true);
+
+    const body = await res.json() as any;
+    expect(body.total_processed).toBe(2);
+    expect(body.total_matched).toBe(1);
+    expect(body.accounts.length).toBe(1);
+    expect(body.accounts[0].username).toBe('traveljane');
+    expect(body.accounts[0].match_score).toBeGreaterThanOrEqual(80);
+    expect(body.payment.txHash).toBe(txHash);
+    expect(body.payment.network).toBe('base');
+    expect(body.payment.settled).toBe(true);
+  });
+});


### PR DESCRIPTION
﻿Adds GET /api/instagram/discover (x402-gated, $0.03) with filters: usernames, niche, min_followers, account_type, sentiment,
brand_safe, limit. Implements discoverAccounts scoring/match reasons in instagram-scraper, updates API endpoint listings, and adds tests for
402 + paid success flow.