### PR TITLE
feat: Add EconBot Earn API - Crypto Intelligence Service

### DIFF
--- a/listings/econbot-earn-api.json
+++ b/listings/econbot-earn-api.json
@@ -1,0 +1,36 @@
+{
+  "id": "econbot-earn-api",
+  "name": "EconBot Earn API",
+  "description": "Crypto intelligence API - prices, gas, airdrops, and social trending data for AI agents",
+  "longDescription": "A self-hostable scraping API that provides real-time crypto prices, ETH gas prices, airdrop opportunities, and social trending data. Built for AI agents that need crypto intelligence without expensive subscriptions. x402 payment gating allows pay-per-request with no API keys.",
+  "endpoint": "https://econbot-earn-api.onrender.com",
+  "docsUrl": "https://github.com/BelialTheRuler/econbot-earn-api",
+  "pricing": {
+    "model": "per-request",
+    "amount": "0.005",
+    "minimum": "0.005",
+    "currency": "USDC",
+    "networks": [
+      {
+        "network": "base",
+        "chainId": "eip155:8453",
+        "recipient": "0x2eD1BE33f2c3F671f7B1C4661766383a226B6466",
+        "asset": "USDC",
+        "assetAddress": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      }
+    ]
+  },
+  "category": "crypto-data",
+  "tags": ["crypto", "prices", "gas", "airdrops", "intelligence", "scraper"],
+  "owner": {
+    "name": "BelialTheRuler",
+    "github": "BelialTheRuler"
+  },
+  "status": "pending",
+  "featured": false,
+  "addedAt": "2026-04-12",
+  "x402": {
+    "discoveryUrl": "https://econbot-earn-api.onrender.com/api/crypto/price",
+    "wellKnown": "https://econbot-earn-api.onrender.com/.well-known/x402"
+  }
+}

--- a/listings/econbot-earn-api.json
+++ b/listings/econbot-earn-api.json
@@ -3,7 +3,7 @@
   "name": "EconBot Earn API",
   "description": "Crypto intelligence API - prices, gas, airdrops, and social trending data for AI agents",
   "longDescription": "A self-hostable scraping API that provides real-time crypto prices, ETH gas prices, airdrop opportunities, and social trending data. Built for AI agents that need crypto intelligence without expensive subscriptions. x402 payment gating allows pay-per-request with no API keys.",
-  "endpoint": "https://econbot-earn-api.onrender.com",
+  "endpoint": "https://econbot-earn-api-production.up.railway.app",
   "docsUrl": "https://github.com/BelialTheRuler/econbot-earn-api",
   "pricing": {
     "model": "per-request",
@@ -30,7 +30,7 @@
   "featured": false,
   "addedAt": "2026-04-12",
   "x402": {
-    "discoveryUrl": "https://econbot-earn-api.onrender.com/api/crypto/price",
-    "wellKnown": "https://econbot-earn-api.onrender.com/.well-known/x402"
+    "discoveryUrl": "https://econbot-earn-api-production.up.railway.app/api/crypto/price",
+    "wellKnown": "https://econbot-earn-api-production.up.railway.app/.well-known/x402"
   }
 }

--- a/listings/index.json
+++ b/listings/index.json
@@ -148,7 +148,7 @@
       "id": "econbot-earn-api",
       "name": "EconBot Earn API",
       "description": "Crypto intelligence API - prices, gas, airdrops, and social trending data for AI agents",
-      "endpoint": "https://econbot-earn-api.onrender.com",
+      "endpoint": "https://econbot-earn-api-production.up.railway.app",
       "docsUrl": "https://github.com/BelialTheRuler/econbot-earn-api",
       "pricing": {
         "model": "per-request",

--- a/listings/index.json
+++ b/listings/index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "updatedAt": "2026-02-15",
-  "count": 6,
+  "updatedAt": "2026-04-12",
+  "count": 7,
   "services": [
     {
       "id": "proxies-sx-mobile",
@@ -143,6 +143,35 @@
       "status": "active",
       "featured": false,
       "detailsFile": "prediction-market-aggregator.json"
+    },
+    {
+      "id": "econbot-earn-api",
+      "name": "EconBot Earn API",
+      "description": "Crypto intelligence API - prices, gas, airdrops, and social trending data for AI agents",
+      "endpoint": "https://econbot-earn-api.onrender.com",
+      "docsUrl": "https://github.com/BelialTheRuler/econbot-earn-api",
+      "pricing": {
+        "model": "per-request",
+        "amount": "0.005",
+        "minimum": "0.005",
+        "currency": "USDC"
+      },
+      "category": "crypto-data",
+      "tags": [
+        "crypto",
+        "prices",
+        "gas",
+        "airdrops",
+        "intelligence",
+        "scraper"
+      ],
+      "owner": {
+        "name": "BelialTheRuler",
+        "github": "BelialTheRuler"
+      },
+      "status": "pending",
+      "featured": false,
+      "detailsFile": "econbot-earn-api.json"
     }
   ],
   "networks": {


### PR DESCRIPTION
## EconBot Earn API - Crypto Intelligence Service

### What
Added a new crypto intelligence scraping API with x402 payment gating.

### Service Details
- **Name:** EconBot Earn API
- **Endpoint:** https://econbot-earn-api.onrender.com
- **Price:** $0.005 USDC per request
- **Network:** Base
- **Category:** crypto-data

### Features
- Crypto prices (BTC, ETH, USDC) from CoinGecko
- ETH gas prices in Gwei
- Airdrop opportunities list
- Social trending from Reddit

### Files Added
- `listings/econbot-earn-api.json` - Service listing
- Updated `listings/index.json` - Added to marketplace index

### Proof
- Live API: https://econbot-earn-api.onrender.com/health
- x402 Discovery: https://econbot-earn-api.onrender.com/.well-known/x402

### Notes
First-time submission. Happy to iterate based on feedback.