### PR TITLE
Add Google SERP Scraper for  bounty - Playwright + mobile proxy support

### DIFF
--- a/serp/README.md
+++ b/serp/README.md
@@ -1,0 +1,14 @@
+# Google SERP Scraper - $200 Bounty Submission
+
+## Description
+A reliable Google Search Results scraper built with Playwright, optimized for mobile proxies.
+
+## Features
+- Mobile user-agent to bypass basic bot detection
+- Structured JSON output (position, title, link, snippet)
+- Proper error handling and cleanup
+- Works with Proxies.sx mobile proxy pool
+
+## Usage
+```bash
+node google-serp-scraper.js "your search query" "http://user:pass@proxy.proxies.sx:port"

--- a/serp/googleserpscraper.js
+++ b/serp/googleserpscraper.js
@@ -1,0 +1,81 @@
+// serp/google-serp-scraper.js
+// Proxies.sx $200 Google SERP Scraper Bounty
+// Built for mobile proxy pool + anti-bot resistance
+
+const { chromium } = require('playwright');
+
+async function scrapeGoogleSERP(query, proxyUrl) {
+  let browser;
+  try {
+    browser = await chromium.launch({
+      proxy: { server: proxyUrl },
+      headless: true,
+    });
+
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+    });
+
+    const page = await context.newPage();
+
+    await page.goto(`https://www.google.com/search?q=${encodeURIComponent(query)}`, {
+      waitUntil: 'networkidle',
+      timeout: 30000,
+    });
+
+    // Extract structured results
+    const results = await page.evaluate(() => {
+      const items = [];
+      document.querySelectorAll('.g').forEach((el, index) => {
+        const titleEl = el.querySelector('h3');
+        const linkEl = el.querySelector('a');
+        const snippetEl = el.querySelector('.VwiC3b') || el.querySelector('.V3FYCf');
+
+        if (titleEl && linkEl) {
+          items.push({
+            position: index + 1,
+            title: titleEl.innerText.trim(),
+            link: linkEl.href,
+            snippet: snippetEl ? snippetEl.innerText.trim() : '',
+          });
+        }
+      });
+      return items;
+    });
+
+    return {
+      success: true,
+      query: query,
+      resultCount: results.length,
+      results: results,
+      timestamp: new Date().toISOString(),
+    };
+
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+      query: query,
+      timestamp: new Date().toISOString(),
+    };
+  } finally {
+    if (browser) await browser.close();
+  }
+}
+
+// Example usage (Proxies.sx will call this with their proxy pool)
+async function main() {
+  const query = process.argv[2] || "best mobile proxies 2026";
+  const proxy = process.argv[3] || "http://user:pass@proxy.proxies.sx:port";
+
+  console.log(`Scraping Google for: "${query}" using proxy: ${proxy}`);
+
+  const result = await scrapeGoogleSERP(query, proxy);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { scrapeGoogleSERP };

--- a/serp/package-lock.json
+++ b/serp/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "google-serp-scraper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "google-serp-scraper",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "^1.48.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/serp/package.json
+++ b/serp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "google-serp-scraper",
+  "version": "1.0.0",
+  "description": "Google SERP Scraper for Proxies.sx bounty - Mobile proxy friendly",
+  "main": "google-serp-scraper.js",
+  "scripts": {
+    "start": "node google-serp-scraper.js",
+    "test": "node google-serp-scraper.js \"test query\" \"http://test-proxy\""
+  },
+  "dependencies": {
+    "playwright": "^1.48.0"
+  }
+}


### PR DESCRIPTION

### Next Step From You

1. Replace the files with the code above (`google-serp-scraper.js`, `package.json`, `README.md` inside the `serp` folder).
2. Run these commands in the `serp` folder:

```bash
npm install
node google-serp-scraper.js "best mobile proxies 2026" "http://test-proxy"   # just to test locally