### PR TITLE
Add web-to-markdown service listing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ PRICE_USDC=0.005
 SERP_SERVICE_NAME=mobile-serp-tracker
 SERP_PRICE_USDC=0.003
 
+# Web Content Extractor (available at /api/extract) — no proxy required
+EXTRACT_SERVICE_NAME=web-to-markdown
+EXTRACT_PRICE_USDC=0.005
+
 # Google Reviews & Business Data API (available at /api/reviews/*, /api/business/*)
 REVIEWS_PRICE_USDC=0.02
 BUSINESS_PRICE_USDC=0.01

--- a/bun.lock
+++ b/bun.lock
@@ -6,24 +6,32 @@
       "name": "marketplace-service-template",
       "dependencies": {
         "hono": "^4.6.0",
+        "turndown": "^7.2.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/turndown": "^5.0.6",
         "typescript": "^5.0.0",
       },
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "https://registry.npmmirror.com/@mixmark-io/domino/-/domino-2.2.0.tgz", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
-    "@types/node": ["@types/node@25.2.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w=="],
+    "@types/bun": ["@types/bun@1.3.8", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.8.tgz", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "@types/node": ["@types/node@25.2.0", "https://registry.npmmirror.com/@types/node/-/node-25.2.0.tgz", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w=="],
 
-    "hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+    "@types/turndown": ["@types/turndown@5.0.6", "https://registry.npmmirror.com/@types/turndown/-/turndown-5.0.6.tgz", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "bun-types": ["bun-types@1.3.8", "https://registry.npmmirror.com/bun-types/-/bun-types-1.3.8.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "hono": ["hono@4.11.7", "https://registry.npmmirror.com/hono/-/hono-4.11.7.tgz", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+
+    "turndown": ["turndown@7.2.4", "https://registry.npmmirror.com/turndown/-/turndown-7.2.4.tgz", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "typescript": ["typescript@5.9.3", "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "https://registry.npmmirror.com/undici-types/-/undici-types-7.16.0.tgz", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/listings/web-to-markdown.json
+++ b/listings/web-to-markdown.json
@@ -1,0 +1,44 @@
+{
+  "id": "web-to-markdown",
+  "name": "Web to Markdown Extractor",
+  "description": "Convert any public URL to clean Markdown. Returns title, meta description, body text, and HTTP metadata in one call.",
+  "longDescription": "Direct HTTP fetch with desktop UA → Turndown HTML→Markdown conversion. Strips scripts/styles/iframes/forms. Returns structured JSON with title, description, contentLength, markdown body, fetch duration, and final URL after redirects. No proxy required for most public sites. Useful for: AI agent content extraction, RAG ingestion, article archival, RSS replacement, link preview generation. Per-request x402 USDC payment on Solana or Base.",
+  "endpoint": "https://CONFIGURED_AT_DEPLOY/api/extract",
+  "docsUrl": "https://CONFIGURED_AT_DEPLOY/",
+  "pricing": {
+    "model": "per-request",
+    "amount": "0.005",
+    "minimum": "0.005",
+    "currency": "USDC",
+    "networks": [
+      {
+        "network": "solana",
+        "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "recipient": "CONFIGURE_WALLET_ADDRESS",
+        "asset": "USDC",
+        "assetAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+      },
+      {
+        "network": "base",
+        "chainId": "eip155:8453",
+        "recipient": "CONFIGURE_WALLET_ADDRESS",
+        "asset": "USDC",
+        "assetAddress": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      }
+    ]
+  },
+  "category": "scraper",
+  "tags": ["markdown", "web-extraction", "html-to-markdown", "url-to-text", "ai-agent", "rag", "content"],
+  "owner": {
+    "name": "wanshouge",
+    "github": "cjjgh",
+    "telegram": "wanshouge"
+  },
+  "status": "pending",
+  "featured": false,
+  "addedAt": "2026-06-10",
+  "x402": {
+    "discoveryUrl": "https://CONFIGURED_AT_DEPLOY/api/extract",
+    "wellKnown": "https://CONFIGURED_AT_DEPLOY/.well-known/x402.json"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "proof:indeed": "bun run scripts/proof-indeed.ts"
   },
   "dependencies": {
-    "hono": "^4.6.0"
+    "hono": "^4.6.0",
+    "turndown": "^7.2.4"
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/turndown": "^5.0.6",
     "typescript": "^5.0.0"
   },
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ app.get('/health', (c) => c.json({
     '/api/run',
     '/api/details',
     '/api/serp',
+    '/api/extract',
     '/api/jobs',
     '/api/reviews/search',
     '/api/reviews/:place_id',
@@ -105,6 +106,7 @@ app.get('/', (c) => c.json({
     { method: 'GET', path: '/api/run', description: 'Google Maps Lead Generator — search businesses by category + location', price: '0.005 USDC' },
     { method: 'GET', path: '/api/details', description: 'Google Maps Place Details — detailed business info by Place ID', price: '0.005 USDC' },
     { method: 'GET', path: '/api/serp', description: 'Mobile SERP Tracker — Google search results with organic, ads, PAA, AI overview', price: '0.003 USDC' },
+    { method: 'GET', path: '/api/extract', description: 'Web Content Extractor — convert any URL to clean Markdown (no proxy required)', price: '0.005 USDC' },
     { method: 'GET', path: '/api/jobs', description: 'Get job listings (Indeed/LinkedIn) with salary + date + proxy metadata' },
     { method: 'GET', path: '/api/reviews/search', description: 'Search businesses by query + location', price: '0.01 USDC' },
     { method: 'GET', path: '/api/reviews/:place_id', description: 'Fetch Google reviews by Place ID', price: '0.02 USDC' },
@@ -137,7 +139,7 @@ app.get('/', (c) => c.json({
       {
         network: 'solana',
         chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        recipient: '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv',
+        recipient: process.env.WALLET_ADDRESS || 'CONFIGURE_WALLET_ADDRESS',
         asset: 'USDC',
         assetAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         settlementTime: '~400ms',
@@ -145,7 +147,7 @@ app.get('/', (c) => c.json({
       {
         network: 'base',
         chainId: 'eip155:8453',
-        recipient: '0xF8cD900794245fc36CBE65be9afc23CDF5103042',
+        recipient: process.env.WALLET_ADDRESS_BASE || process.env.WALLET_ADDRESS || 'CONFIGURE_WALLET_ADDRESS',
         asset: 'USDC',
         assetAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
         settlementTime: '~2s',
@@ -162,7 +164,7 @@ app.get('/', (c) => c.json({
 
 app.route('/api', serviceRouter);
 
-app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/audit/:username', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending'] }, 404));
+app.notFound((c) => c.json({ error: 'Not found', endpoints: ['/', '/health', '/api/run', '/api/details', '/api/serp', '/api/extract', '/api/jobs', '/api/reviews/search', '/api/reviews/:place_id', '/api/business/:place_id', '/api/reviews/summary/:place_id', '/api/linkedin/person', '/api/linkedin/company', '/api/linkedin/search/people', '/api/reddit/search', '/api/reddit/trending', '/api/reddit/subreddit/:name', '/api/reddit/thread/*', '/api/instagram/profile/:username', '/api/instagram/posts/:username', '/api/instagram/analyze/:username', '/api/instagram/audit/:username', '/api/airbnb/search', '/api/airbnb/listing/:id', '/api/airbnb/reviews/:listing_id', '/api/airbnb/market-stats', '/api/research', '/api/trending'] }, 404));
 
 app.onError((err, c) => {
   console.error(`[ERROR] ${err.message}`);

--- a/src/payment.ts
+++ b/src/payment.ts
@@ -128,7 +128,7 @@ export function build402Response(
       {
         network: 'base',
         chainId: 'eip155:8453',
-        recipient: process.env.WALLET_ADDRESS_BASE || '0xF8cD900794245fc36CBE65be9afc23CDF5103042',
+        recipient: process.env.WALLET_ADDRESS_BASE || process.env.WALLET_ADDRESS || 'CONFIGURE_WALLET_ADDRESS',
         asset: 'USDC',
         assetAddress: USDC_BASE,
       },

--- a/src/scrapers/markdown.ts
+++ b/src/scrapers/markdown.ts
@@ -1,0 +1,190 @@
+/**
+ * Web Content Extractor — Direct HTTP → Markdown
+ *
+ * No proxy dependency. Uses direct fetch with desktop UA.
+ * Sites that block datacenter IPs will fail (use Proxies.sx later if needed).
+ */
+
+import TurndownService from 'turndown';
+
+const DEFAULT_RULES = {
+  headingStyle: 'atx' as const,
+  codeBlockStyle: 'fenced' as const,
+  bulletListMarker: '-' as const,
+  emDelimiter: '_' as const,
+  strongDelimiter: '**' as const,
+};
+
+const MAX_HTML_BYTES = 5_000_000;
+const DESKTOP_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const MAX_TITLE_LENGTH = 300;
+const MAX_DESC_LENGTH = 500;
+const MAX_URL_LENGTH = 2048;
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(Math.floor(value), min), max);
+}
+
+function sanitizeText(value: string, maxLen: number): string {
+  return value.replace(/[\r\n\0]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, maxLen);
+}
+
+function buildConverter(includeLinks: boolean, includeImages: boolean): TurndownService {
+  const td = new TurndownService(DEFAULT_RULES);
+  // @ts-ignore — Turndown types are overly strict on the filter array
+  td.addRule('strikethrough', {
+    filter: ['del', 's'] as any,
+    replacement: (content: string) => `~~${content}~~`,
+  });
+  if (includeLinks) {
+    // @ts-ignore
+    td.addRule('defaultLink', {
+      filter: 'a' as any,
+      replacement: (content: string, node: any) => {
+        const href = (node.getAttribute && node.getAttribute('href')) || '';
+        if (!href || href.startsWith('#')) return content;
+        return `[${content}](${href})`;
+      },
+    });
+  } else {
+    // @ts-ignore
+    td.remove('a' as any);
+  }
+  if (includeImages) {
+    // @ts-ignore
+    td.addRule('defaultImage', {
+      filter: 'img' as any,
+      replacement: (_content: string, node: any) => {
+        const src = (node.getAttribute && node.getAttribute('src')) || '';
+        const alt = (node.getAttribute && node.getAttribute('alt')) || '';
+        if (!src) return '';
+        return `![${alt}](${src})`;
+      },
+    });
+  } else {
+    // @ts-ignore
+    td.remove('img' as any);
+  }
+  // Strip noise
+  // @ts-ignore
+  td.remove(['script', 'style', 'noscript', 'iframe', 'svg', 'form', 'button', 'input']);
+  return td;
+}
+
+export interface MarkdownResult {
+  url: string;
+  finalUrl: string;
+  statusCode: number;
+  title: string;
+  description: string;
+  contentType: string;
+  contentLength: number;
+  markdown: string;
+  markdownLength: number;
+  truncated: boolean;
+  fetchDurationMs: number;
+  fetchedAt: string;
+}
+
+export interface ExtractOptions {
+  maxChars?: number;
+  includeLinks?: boolean;
+  includeImages?: boolean;
+  timeoutMs?: number;
+}
+
+export async function extractMarkdown(
+  url: string,
+  options: ExtractOptions = {},
+): Promise<MarkdownResult> {
+  const {
+    maxChars = 50_000,
+    includeLinks = true,
+    includeImages = true,
+    timeoutMs = 30_000,
+  } = options;
+
+  // Validate URL
+  if (typeof url !== 'string' || url.length > MAX_URL_LENGTH) {
+    throw new Error('URL too long or invalid');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('Invalid URL — must include protocol (https://)');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Invalid protocol: ${parsed.protocol} (only http/https)`);
+  }
+  // SSRF protection
+  const blocked = ['localhost', '127.0.0.1', '0.0.0.0', '::1', '169.254.169.254'];
+  if (blocked.includes(parsed.hostname) || parsed.hostname.endsWith('.local') || parsed.hostname.endsWith('.internal')) {
+    throw new Error('Internal/private URLs not allowed');
+  }
+
+  const safeMaxChars = clamp(maxChars, 1000, 200_000);
+  const converter = buildConverter(includeLinks, includeImages);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const start = Date.now();
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': DESKTOP_UA,
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9,zh;q=0.8',
+      },
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+
+    if (!response.ok) {
+      throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
+    }
+
+    const contentLengthHeader = parseInt(response.headers.get('content-length') || '0');
+    if (contentLengthHeader > MAX_HTML_BYTES) {
+      throw new Error(`Content too large: ${contentLengthHeader} bytes (max ${MAX_HTML_BYTES})`);
+    }
+
+    const body = await response.arrayBuffer();
+    if (body.byteLength > MAX_HTML_BYTES) {
+      throw new Error(`Content too large: ${body.byteLength} bytes (max ${MAX_HTML_BYTES})`);
+    }
+    const html = new TextDecoder('utf-8', { fatal: false }).decode(body);
+
+    let markdown = converter.turndown(html);
+    let truncated = false;
+    if (markdown.length > safeMaxChars) {
+      markdown = markdown.slice(0, safeMaxChars) + `\n\n*[... truncated at ${safeMaxChars} chars ...]*`;
+      truncated = true;
+    }
+
+    const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    const title = titleMatch ? sanitizeText(titleMatch[1], MAX_TITLE_LENGTH) : '';
+    const descMatch = html.match(/<meta\s+name=["']description["']\s+content=["']([^"']*)["']/i)
+      ?? html.match(/<meta\s+content=["']([^"']*)["']\s+name=["']description["']/i);
+    const description = descMatch ? sanitizeText(descMatch[1], MAX_DESC_LENGTH) : '';
+
+    return {
+      url,
+      finalUrl: response.url,
+      statusCode: response.status,
+      title,
+      description,
+      contentType: response.headers.get('content-type') || 'unknown',
+      contentLength: html.length,
+      markdown,
+      markdownLength: markdown.length,
+      truncated,
+      fetchDurationMs: Date.now() - start,
+      fetchedAt: new Date().toISOString(),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -247,7 +247,10 @@ serviceRouter.get('/details', async (c) => {
 });
 
 serviceRouter.get('/jobs', async (c) => {
-  const walletAddress = '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -807,7 +810,7 @@ const REDDIT_COMMENTS_PRICE = 0.01;  // $0.01 per comment thread
 // ─── GET /api/reddit/search ─────────────────────────
 
 serviceRouter.get('/reddit/search', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -861,7 +864,7 @@ serviceRouter.get('/reddit/search', async (c) => {
 // ─── GET /api/reddit/trending ───────────────────────
 
 serviceRouter.get('/reddit/trending', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -903,7 +906,7 @@ serviceRouter.get('/reddit/trending', async (c) => {
 // ─── GET /api/reddit/subreddit/:name ────────────────
 
 serviceRouter.get('/reddit/subreddit/:name', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -957,7 +960,7 @@ serviceRouter.get('/reddit/subreddit/:name', async (c) => {
 // ─── GET /api/reddit/thread/:id ─────────────────────
 
 serviceRouter.get('/reddit/thread/*', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -1263,7 +1266,7 @@ const AIRBNB_MARKET_STATS_PRICE = 0.05;
 // ─── GET /api/airbnb/search ─────────────────────────
 
 serviceRouter.get('/airbnb/search', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -1313,7 +1316,7 @@ serviceRouter.get('/airbnb/search', async (c) => {
 // ─── GET /api/airbnb/listing/:id ────────────────────
 
 serviceRouter.get('/airbnb/listing/:id', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -1352,7 +1355,7 @@ serviceRouter.get('/airbnb/listing/:id', async (c) => {
 // ─── GET /api/airbnb/reviews/:listing_id ────────────
 
 serviceRouter.get('/airbnb/reviews/:listing_id', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -1396,7 +1399,7 @@ serviceRouter.get('/airbnb/reviews/:listing_id', async (c) => {
 // ─── GET /api/airbnb/market-stats ───────────────────
 
 serviceRouter.get('/airbnb/market-stats', async (c) => {
-  const walletAddress = process.env.SOLANA_WALLET_ADDRESS || '6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv';
+  const walletAddress = process.env.WALLET_ADDRESS || '';
 
   const payment = extractPayment(c);
   if (!payment) {
@@ -1471,7 +1474,7 @@ serviceRouter.get('/serp', async (c) => {
   try {
     const proxy = getProxy();
     const ip = await getProxyExitIp();
-    const results = await scrapeMobileSERP(query, { location, num });
+    const results = await scrapeMobileSERP(query, 'us', 'en', location, 0);
 
     c.header('X-Payment-Settled', 'true');
     c.header('X-Payment-TxHash', payment.txHash);
@@ -1484,5 +1487,91 @@ serviceRouter.get('/serp', async (c) => {
     });
   } catch (err: any) {
     return c.json({ error: 'SERP scrape failed', message: err?.message || String(err) }, 502);
+  }
+});
+
+// ═══════════════════════════════════════════════════════
+// ─── WEB CONTENT EXTRACTOR → MARKDOWN (no proxy) ────
+// ═══════════════════════════════════════════════════════
+
+import { extractMarkdown } from './scrapers/markdown';
+
+const EXTRACT_PRICE_USDC = parseFloat(process.env.EXTRACT_PRICE_USDC || '0.005');
+const EXTRACT_DESCRIPTION = 'Web Content Extractor — convert any public URL to clean Markdown. Returns title, meta description, body text, and HTTP metadata. Direct HTTP fetch (no proxy required).';
+const EXTRACT_OUTPUT_SCHEMA = {
+  input: {
+    url: 'string (required) — full URL with protocol (https://example.com)',
+    maxChars: 'number (optional, default 50000) — truncate markdown to N characters (max 200000)',
+    includeLinks: 'boolean (optional, default true) — include hyperlinks in output',
+    includeImages: 'boolean (optional, default true) — include image markdown',
+  },
+  output: {
+    url: 'string — original URL',
+    finalUrl: 'string — URL after redirects',
+    statusCode: 'number — HTTP status code',
+    title: 'string — page <title>',
+    description: 'string — meta description',
+    contentType: 'string — Content-Type header',
+    contentLength: 'number — raw HTML bytes',
+    markdown: 'string — cleaned Markdown content',
+    markdownLength: 'number — markdown character count',
+    truncated: 'boolean — whether output was truncated to maxChars',
+    fetchDurationMs: 'number — time spent fetching',
+    fetchedAt: 'string — ISO 8601 timestamp',
+    payment: '{ txHash, network, amount, settled }',
+  },
+};
+
+serviceRouter.get('/extract', async (c) => {
+  const walletAddress = process.env.WALLET_ADDRESS;
+  if (!walletAddress) {
+    return c.json({ error: 'Service misconfigured: WALLET_ADDRESS not set' }, 500);
+  }
+
+  const payment = extractPayment(c);
+  if (!payment) {
+    return c.json(
+      build402Response('/api/extract', EXTRACT_DESCRIPTION, EXTRACT_PRICE_USDC, walletAddress, EXTRACT_OUTPUT_SCHEMA),
+      402,
+    );
+  }
+
+  const verification = await verifyPayment(payment, walletAddress, EXTRACT_PRICE_USDC);
+  if (!verification.valid) {
+    return c.json({ error: 'Payment verification failed', reason: verification.error }, 402);
+  }
+
+  const url = c.req.query('url');
+  if (!url) {
+    return c.json({
+      error: 'Missing required parameter: url',
+      example: '/api/extract?url=https://example.com',
+      hint: 'Provide a full URL with protocol',
+    }, 400);
+  }
+
+  const maxChars = parseInt(c.req.query('maxChars') || '50000');
+  if (isNaN(maxChars) || maxChars < 1000) {
+    return c.json({ error: 'Invalid maxChars — must be >= 1000' }, 400);
+  }
+  const includeLinks = c.req.query('includeLinks') !== 'false';
+  const includeImages = c.req.query('includeImages') !== 'false';
+
+  try {
+    const result = await extractMarkdown(url, { maxChars, includeLinks, includeImages });
+
+    c.header('X-Payment-Settled', 'true');
+    c.header('X-Payment-TxHash', payment.txHash);
+
+    return c.json({
+      ...result,
+      payment: { txHash: payment.txHash, network: payment.network, amount: verification.amount, settled: true },
+    });
+  } catch (err: any) {
+    return c.json({
+      error: 'Extraction failed',
+      message: err?.message || String(err),
+      hint: 'URL may be unreachable, blocking direct requests, or returning non-HTML content. Some sites require mobile proxy access (Proxies.sx).',
+    }, 502);
   }
 });


### PR DESCRIPTION
Adding a new marketplace service: **web-to-markdown** — converts any public URL to clean Markdown via direct HTTP fetch + Turndown. No proxy required, useful for AI agent content extraction / RAG ingestion.

Endpoint: `GET /api/extract?url=<URL>`
Price: 0.005 USDC per request
Networks: Solana + Base (USDC)

Implementation:
- New scraper: `src/scrapers/markdown.ts` (Turndown + SSRF protection + URL validation)
- New endpoint: `GET /api/extract` in `src/service.ts`
- Service discovery updated in `src/index.ts`
- All hardcoded wallet addresses refactored to env vars

Fork: https://github.com/cjjgh/marketplace-service-template